### PR TITLE
Pass in params instead of ctx.params

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -328,7 +328,7 @@ module.exports = {
 							return Promise.reject(new EntityNotFoundError(id));
 
 						origDoc = doc;
-						return this.transformDocuments(ctx, ctx.params, doc);
+						return this.transformDocuments(ctx, params, doc);
 					})
 
 					.then(json => {


### PR DESCRIPTION
Get function is not passing in the sanitized params when calling transformDocuments where, the list function does. This causes a bug where when passing in ?populate=fieldname in query string to not populate. The populateDoc function expects an array.