### PR TITLE
fix: Wait for cache clear

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -266,7 +266,7 @@ module.exports = {
 									if (this.settings.idField === "_id") return entities;
 
 									return entities.map(entity => this.adapter.beforeSaveTransformID(entity, this.settings.idField));
-									
+
 								})
 								.then(entities => this.adapter.insertMany(entities));
 						} else if (params.entity) {
@@ -544,7 +544,7 @@ module.exports = {
 		clearCache() {
 			this.broker.broadcast(`cache.clean.${this.name}`);
 			if (this.broker.cacher)
-				this.broker.cacher.clean(`${this.name}.*`);
+				return this.broker.cacher.clean(`${this.name}.*`);
 			return Promise.resolve();
 		},
 
@@ -562,7 +562,7 @@ module.exports = {
 					isDoc = true;
 					docs = [docs];
 				}
-				else 
+				else
 					return Promise.resolve(docs);
 			}
 

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -423,7 +423,7 @@ describe("Test DbService methods", () => {
 
 	it("should call broker.broadcast to clear the cache", () => {
 		broker.broadcast = jest.fn();
-		broker.cacher.clean = jest.fn();
+		broker.cacher.clean = jest.fn(() => Promise.resolve());
 
 		return service.clearCache().then(() => {
 			expect(broker.broadcast).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
When you use `RedisCacher`, and you do `get` and just after `update` on a service with a model, sometime you will get the older cached value.
And after a little of troubleshoot, i find that any update/delete action do not wait for cache to clear before returning the action. (Not visible with memory cacher because synchronous)
The little fix it's to return the promise of `this.broker.cacher.clean` in the `clearCache` function.
And it was fix.