### PR TITLE
UPDATE: cache clear bug resolved

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -542,9 +542,9 @@ module.exports = {
 		 * @returns {Promise}
 		 */
 		clearCache() {
-			this.broker.broadcast(`cache.clean.${this.name}`);
+			this.broker.broadcast(`cache.clean.${this.fullName}`);
 			if (this.broker.cacher)
-				return this.broker.cacher.clean(`${this.name}.*`);
+				return this.broker.cacher.clean(`${this.fullName}.*`);
 			return Promise.resolve();
 		},
 

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -428,10 +428,10 @@ describe("Test DbService methods", () => {
 
 		return service.clearCache().then(() => {
 			expect(broker.broadcast).toHaveBeenCalledTimes(1);
-			expect(broker.broadcast).toHaveBeenCalledWith("cache.clean." + service.fullName);
+			expect(broker.broadcast).toHaveBeenCalledWith("cache.clean.v1.store");
 
 			expect(broker.cacher.clean).toHaveBeenCalledTimes(1);
-			expect(broker.cacher.clean).toHaveBeenCalledWith(service.fullName + ".*");
+			expect(broker.cacher.clean).toHaveBeenCalledWith("v1.store.*");
 		}).catch(protectReject);
 	});
 

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -410,6 +410,7 @@ describe("Test DbService methods", () => {
 	const broker = new ServiceBroker({ logger: false, validation: false, cacher: true });
 	const service = broker.createService(DbService, {
 		name: "store",
+		version: 1,
 		adapter,
 		afterConnected
 	});
@@ -427,10 +428,10 @@ describe("Test DbService methods", () => {
 
 		return service.clearCache().then(() => {
 			expect(broker.broadcast).toHaveBeenCalledTimes(1);
-			expect(broker.broadcast).toHaveBeenCalledWith("cache.clean.store");
+			expect(broker.broadcast).toHaveBeenCalledWith("cache.clean." + service.fullName);
 
 			expect(broker.cacher.clean).toHaveBeenCalledTimes(1);
-			expect(broker.cacher.clean).toHaveBeenCalledWith("store.*");
+			expect(broker.cacher.clean).toHaveBeenCalledWith(service.fullName + ".*");
 		}).catch(protectReject);
 	});
 


### PR DESCRIPTION
When a service has a version number then its cache is being saved as v1.service.find instead of service.find
this version number of the service is present in fullName if a version number is used, otherwise fullName only contain name of service. So using fullName instead of name in clearCache resolves this problem.