### PR TITLE
fix: docs validation in populateDocs

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -676,7 +676,7 @@ module.exports = {
 			if (!this.settings.populates || !Array.isArray(populateFields) || populateFields.length == 0)
 				return Promise.resolve(docs);
 
-			if (docs == null || !_.isObject(docs) || !Array.isArray(docs))
+			if (docs == null || !_.isObject(docs) && !Array.isArray(docs))
 				return Promise.resolve(docs);
 
 			let promises = [];


### PR DESCRIPTION
In moleculer-db package, in index.js, the populateDocs function validates the docs parameter incorrectly, using an || forcing the parameter to be an array. By using an && it allows for the intended types of object or array.