### PR TITLE
Fixed date comparison in CREATE new post test

### DIFF
--- a/packages/moleculer-db/examples/simple/index.js
+++ b/packages/moleculer-db/examples/simple/index.js
@@ -75,7 +75,7 @@ checker.add("COUNT", () => broker.call("posts.count"), res => {
 checker.add("--- CREATE ---", () => broker.call("posts.create", { title: "Hello", content: "Post content", votes: 2, createdAt: date, status: true }), doc => {
 	id = doc._id;
 	console.log("Saved: ", doc);
-	return doc._id && doc.title === "Hello" && doc.content === "Post content" && doc.votes === 2 && doc.createdAt === date;
+	return doc._id && doc.title === "Hello" && doc.content === "Post content" && doc.votes === 2 && doc.createdAt.getTime() === date.getTime();
 });
 
 // Find posts


### PR DESCRIPTION
Hi,

Before everything else, I noticed a failed test in examples/single/index.js. It is caused by a date comparison returning false and the solution I've found (on StackOverflow :P) is to rely on date.getTime() instead of comparing date objects.

https://stackoverflow.com/questions/492994/compare-two-dates-with-javascript

Best,
Razvan