### PR TITLE
added noSync to SqlAdapter

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -61,7 +61,12 @@ class SequelizeDbAdapter {
 		return this.db.authenticate().then(() => {
 			let modelDefinitionOrInstance = this.service.schema.model;
 
-			const noSync = this.opts[3] && this.opts[3].noSync;
+			let noSync = false;
+			if (this.opts[3]) {
+				noSync = !!this.opts[3].noSync;
+			} else if (this.opts[0].dialect === "sqlite") {
+				noSync = !!this.opts[0].noSync;
+			}
 
 			let modelReadyPromise;
 			let isModelInstance = modelDefinitionOrInstance

--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -60,6 +60,9 @@ class SequelizeDbAdapter {
 
 		return this.db.authenticate().then(() => {
 			let modelDefinitionOrInstance = this.service.schema.model;
+
+			const noSync = this.opts[3] && this.opts[3].noSync;
+
 			let modelReadyPromise;
 			let isModelInstance = modelDefinitionOrInstance
 				&& (Object.prototype.hasOwnProperty.call(modelDefinitionOrInstance, "attributes")
@@ -69,7 +72,7 @@ class SequelizeDbAdapter {
 				modelReadyPromise = Promise.resolve();
 			} else {
 				this.model = this.db.define(modelDefinitionOrInstance.name, modelDefinitionOrInstance.define, modelDefinitionOrInstance.options);
-				modelReadyPromise  = this.model.sync();
+				modelReadyPromise = noSync ? Promise.resolve(this.model) : this.model.sync();
 			}
 			this.service.model = this.model;
 

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const {ServiceBroker} = require("moleculer");
+const { ServiceBroker } = require("moleculer");
 
 jest.mock("sequelize");
 
@@ -29,7 +29,7 @@ Sequelize.mockImplementation(() => db);
 
 const SequelizeAdapter = require("../../src");
 
-function protectReject (err) {
+function protectReject(err) {
 	if (err && err.stack) {
 		console.error(err);
 		console.error(err.stack);
@@ -63,6 +63,7 @@ describe("Test SequelizeAdapter", () => {
 		Sequelize.mockClear();
 		db.authenticate.mockClear();
 		db.define.mockClear();
+		model.sync.mockClear();
 	});
 
 	describe("model definition as description", () => {
@@ -71,7 +72,7 @@ describe("Test SequelizeAdapter", () => {
 		};
 		const adapter = new SequelizeAdapter(opts);
 
-		const broker = new ServiceBroker({logger: false});
+		const broker = new ServiceBroker({ logger: false });
 		const service = broker.createService({
 			name: "store",
 			model: fakeModel
@@ -155,23 +156,23 @@ describe("Test SequelizeAdapter", () => {
 			it("call with query", () => {
 				adapter.model.findAll.mockClear();
 				let query = {};
-				adapter.createCursor({query});
+				adapter.createCursor({ query });
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
-				expect(adapter.model.findAll).toHaveBeenCalledWith({where: query});
+				expect(adapter.model.findAll).toHaveBeenCalledWith({ where: query });
 			});
 
 			it("call with query & counting", () => {
 				adapter.model.count.mockClear();
 				let query = {};
-				adapter.createCursor({query}, true);
+				adapter.createCursor({ query }, true);
 				expect(adapter.model.count).toHaveBeenCalledTimes(1);
-				expect(adapter.model.count).toHaveBeenCalledWith({where: query});
+				expect(adapter.model.count).toHaveBeenCalledWith({ where: query });
 			});
 
 			it("call with sort string", () => {
 				adapter.model.findAll.mockClear();
 				let query = {};
-				adapter.createCursor({query, sort: "-votes title"});
+				adapter.createCursor({ query, sort: "-votes title" });
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
 				expect(adapter.model.findAll).toHaveBeenCalledWith({
 					where: query,
@@ -182,7 +183,7 @@ describe("Test SequelizeAdapter", () => {
 			it("call with sort array", () => {
 				adapter.model.findAll.mockClear();
 				let query = {};
-				adapter.createCursor({query, sort: ["createdAt", "title"]});
+				adapter.createCursor({ query, sort: ["createdAt", "title"] });
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
 				expect(adapter.model.findAll).toHaveBeenCalledWith({
 					where: query,
@@ -193,7 +194,7 @@ describe("Test SequelizeAdapter", () => {
 			it("call with sort object", () => {
 				adapter.model.findAll.mockClear();
 				let query = {};
-				adapter.createCursor({query, sort: {createdAt: 1, title: -1}});
+				adapter.createCursor({ query, sort: { createdAt: 1, title: -1 } });
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
 				expect(adapter.model.findAll).toHaveBeenCalledWith({
 					where: query,
@@ -203,7 +204,7 @@ describe("Test SequelizeAdapter", () => {
 
 			it("call with limit & offset", () => {
 				adapter.model.findAll.mockClear();
-				adapter.createCursor({limit: 5, offset: 10});
+				adapter.createCursor({ limit: 5, offset: 10 });
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
 				expect(adapter.model.findAll).toHaveBeenCalledWith({
 					offset: 10,
@@ -214,7 +215,7 @@ describe("Test SequelizeAdapter", () => {
 
 			it("call with full-text search", () => {
 				adapter.model.findAll.mockClear();
-				adapter.createCursor({search: "walter", searchFields: ["title", "content"]});
+				adapter.createCursor({ search: "walter", searchFields: ["title", "content"] });
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
 				expect(adapter.model.findAll).toHaveBeenCalledWith({
 					where: {
@@ -249,7 +250,7 @@ describe("Test SequelizeAdapter", () => {
 
 		it("call findOne", () => {
 			adapter.model.findOne.mockClear();
-			let age = {age: 25};
+			let age = { age: 25 };
 
 			return adapter.findOne(age).catch(protectReject).then(() => {
 				expect(adapter.model.findOne).toHaveBeenCalledTimes(1);
@@ -271,7 +272,7 @@ describe("Test SequelizeAdapter", () => {
 
 			return adapter.findByIds([5]).catch(protectReject).then(() => {
 				expect(adapter.model.findAll).toHaveBeenCalledTimes(1);
-				expect(adapter.model.findAll).toHaveBeenCalledWith({"where": {"id": {[Op.in]: [5]}}});
+				expect(adapter.model.findAll).toHaveBeenCalledWith({ "where": { "id": { [Op.in]: [5] } } });
 			});
 		});
 
@@ -295,7 +296,7 @@ describe("Test SequelizeAdapter", () => {
 
 		it("call inserts", () => {
 			adapter.model.create.mockClear();
-			let entities = [{name: "John"}, {name: "Jane"}];
+			let entities = [{ name: "John" }, { name: "Jane" }];
 
 			return adapter.insertMany(entities).catch(protectReject).then(() => {
 				expect(adapter.model.bulkCreate).toHaveBeenCalledTimes(1);
@@ -310,7 +311,7 @@ describe("Test SequelizeAdapter", () => {
 			return adapter.updateMany(where, update).catch(protectReject).then(res => {
 				expect(res).toBe(1);
 				expect(adapter.model.update).toHaveBeenCalledTimes(1);
-				expect(adapter.model.update).toHaveBeenCalledWith(update, {where});
+				expect(adapter.model.update).toHaveBeenCalledWith(update, { where });
 			});
 		});
 
@@ -321,7 +322,7 @@ describe("Test SequelizeAdapter", () => {
 			}));
 
 			let update = {
-				$set: {title: "Test"}
+				$set: { title: "Test" }
 			};
 			return adapter.updateById(5, update).catch(protectReject).then(() => {
 				expect(adapter.findById).toHaveBeenCalledTimes(1);
@@ -337,7 +338,7 @@ describe("Test SequelizeAdapter", () => {
 
 			return adapter.removeMany(where).catch(protectReject).then(() => {
 				expect(adapter.model.destroy).toHaveBeenCalledTimes(1);
-				expect(adapter.model.destroy).toHaveBeenCalledWith({where});
+				expect(adapter.model.destroy).toHaveBeenCalledWith({ where });
 			});
 		});
 
@@ -360,7 +361,7 @@ describe("Test SequelizeAdapter", () => {
 			adapter.model.destroy.mockClear();
 			return adapter.clear().catch(protectReject).then(() => {
 				expect(adapter.model.destroy).toHaveBeenCalledTimes(1);
-				expect(adapter.model.destroy).toHaveBeenCalledWith({where: {}});
+				expect(adapter.model.destroy).toHaveBeenCalledWith({ where: {} });
 			});
 		});
 
@@ -370,7 +371,7 @@ describe("Test SequelizeAdapter", () => {
 			};
 			adapter.entityToObject(doc);
 			expect(doc.get).toHaveBeenCalledTimes(1);
-			expect(doc.get).toHaveBeenCalledWith({plain: true});
+			expect(doc.get).toHaveBeenCalledWith({ plain: true });
 		});
 
 
@@ -401,7 +402,7 @@ describe("Test SequelizeAdapter", () => {
 		};
 		const adapter = new SequelizeAdapter(opts);
 
-		const broker = new ServiceBroker({logger: false});
+		const broker = new ServiceBroker({ logger: false });
 		const service = broker.createService({
 			name: "store",
 			model: initiatedModel
@@ -429,7 +430,7 @@ describe("Test SequelizeAdapter", () => {
 		});
 		const adapter = new SequelizeAdapter(opts);
 
-		const broker = new ServiceBroker({logger: false});
+		const broker = new ServiceBroker({ logger: false });
 		const service = broker.createService({
 			name: "store",
 			model: initiatedModel
@@ -461,7 +462,7 @@ describe("Test SequelizeAdapter", () => {
 		const broker = new ServiceBroker({ logger: false });
 		const service = broker.createService({
 			name: "store",
-			model: initiatedModel
+			model: fakeModel
 		});
 		beforeEach(() => {
 			adapter.init(broker, service);
@@ -473,9 +474,11 @@ describe("Test SequelizeAdapter", () => {
 				expect(Sequelize).toHaveBeenCalledWith(opts);
 				expect(adapter.db).toBe(db);
 				expect(adapter.db.authenticate).toHaveBeenCalledTimes(1);
-				expect(adapter.db.define).toHaveBeenCalledTimes(0);
-				expect(adapter.model).toBe(initiatedModel);
-				expect(adapter.service.model).toBe(initiatedModel);
+				expect(adapter.db.define).toHaveBeenCalledTimes(1);
+				expect(adapter.model).toBe(model);
+				expect(adapter.service.model).toBe(model);
+
+				expect(adapter.model.sync).toHaveBeenCalledTimes(0);
 			});
 		});
 	});

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -451,5 +451,33 @@ describe("Test SequelizeAdapter", () => {
 		});
 	});
 
+	describe("noSync option set to true", () => {
+		const opts = {
+			dialect: "sqlite",
+			noSync: true
+		};
+		const adapter = new SequelizeAdapter(opts);
+
+		const broker = new ServiceBroker({ logger: false });
+		const service = broker.createService({
+			name: "store",
+			model: initiatedModel
+		});
+		beforeEach(() => {
+			adapter.init(broker, service);
+		});
+
+		it("do not sync the model with database", () => {
+			return adapter.connect().catch(protectReject).then(() => {
+				expect(Sequelize).toHaveBeenCalledTimes(1);
+				expect(Sequelize).toHaveBeenCalledWith(opts);
+				expect(adapter.db).toBe(db);
+				expect(adapter.db.authenticate).toHaveBeenCalledTimes(1);
+				expect(adapter.db.define).toHaveBeenCalledTimes(0);
+				expect(adapter.model).toBe(initiatedModel);
+				expect(adapter.service.model).toBe(initiatedModel);
+			});
+		});
+	});
 });
 


### PR DESCRIPTION
You are able to set a new config property "noSync", when creating a new instance of SqlAdapter.

`new SqlAdapter(credentials.database, credentials.user, credentials.password, {  
        host: credentials.host,  
        dialect: "mysql",  
        pool: {  
            max: 5,  
            min: 0,  
            idle: 10000  
        },  
        define: {  
            // logging: false,  
            timestamps: false,  
            freezeTableName: true  
        },  
        noSync: true  
})`

If the property is set to true, the model will not be synced by Sequelize.
If your database user doesn't have permission to create a table, SQL will throw an error and you can't use this adapter.
If the "noSync" property is not provided, nothing will change to the previous logic.