### PR TITLE
Add MemoryAdapter to DbService types

### DIFF
--- a/packages/moleculer-db/moleculer-db.d.ts
+++ b/packages/moleculer-db/moleculer-db.d.ts
@@ -12,7 +12,7 @@ declare module "moleculer-db" {
   }
 
   export default class DbService<T=any,S extends DbServiceSettings = DbServiceSettings> extends Service<S> {
- 
+    static MemoryAdapter: { new(opts?: DataStoreOptions): DbService }
   }
 
   export interface QueryOptions<T> {


### PR DESCRIPTION
MemoryAdaptor was not exposed. This adds it. But it still feels like these types are incomplete. Is DbService supposed to implement the `MoleculerDB` interface?

This fixes my issue for now.