### PR TITLE
Add Model Sync when loading from file

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -66,19 +66,19 @@ class SequelizeDbAdapter {
 				noSync = !!this.opts[3].noSync;
 			} else if (this.opts[0].dialect === "sqlite") {
 				noSync = !!this.opts[0].noSync;
+			} else if (this.opts[0] instanceof Sequelize &&	this.opts[1] === "noSync") {
+				noSync = true;
 			}
 
-			let modelReadyPromise;
 			let isModelInstance = modelDefinitionOrInstance
 				&& (Object.prototype.hasOwnProperty.call(modelDefinitionOrInstance, "attributes")
 					|| modelDefinitionOrInstance.prototype instanceof Model);
 			if (isModelInstance) {
 				this.model = modelDefinitionOrInstance;
-				modelReadyPromise = Promise.resolve();
 			} else {
 				this.model = this.db.define(modelDefinitionOrInstance.name, modelDefinitionOrInstance.define, modelDefinitionOrInstance.options);
-				modelReadyPromise = noSync ? Promise.resolve(this.model) : this.model.sync();
 			}
+			const modelReadyPromise = noSync ? Promise.resolve(this.model) : this.model.sync();
 			this.service.model = this.model;
 
 			return modelReadyPromise.then(() => {

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -47,7 +47,8 @@ const fakeModel = {
 	}
 };
 const initiatedModel = {
-	attributes: {}
+	attributes: {}, 
+	sync: jest.fn(() => Promise.resolve()),
 };
 
 
@@ -64,6 +65,7 @@ describe("Test SequelizeAdapter", () => {
 		db.authenticate.mockClear();
 		db.define.mockClear();
 		model.sync.mockClear();
+		initiatedModel.sync.mockClear();
 	});
 
 	describe("model definition as description", () => {
@@ -448,6 +450,8 @@ describe("Test SequelizeAdapter", () => {
 				expect(adapter.db.define).toHaveBeenCalledTimes(0);
 				expect(adapter.model).toBe(initiatedModel);
 				expect(adapter.service.model).toBe(initiatedModel);
+
+				expect(adapter.model.sync).toHaveBeenCalledTimes(1);
 			});
 		});
 	});


### PR DESCRIPTION
I had the problem of loading a model file generated with Sequelize CLI, ex:

`// models/product.js

'use strict'
module.exports = (sequelize, DataTypes) => {
  const product = sequelize.define(
    'product',
    {
      name: DataTypes.STRING,
      description: DataTypes.TEXT,
      status: DataTypes.BOOLEAN,
    },
    {}
  )
  product.associate = function (models) {
    // associations can be defined here
  }
  return product
}
`
I Load the file using the Mixin model

`// db.mixin.js

'use strict'

const DbService = require('moleculer-db')
const SqlAdapter = require('moleculer-db-adapter-sequelize')
const { Sequelize, DataTypes } = require('sequelize')

const env = process.env.NODE_ENV
const dbConfig = require('./config')[env]
const dbModel = require('./models/product')

/**
 * @typedef {import('moleculer').Context} Context Moleculer's Context
 */

module.exports = function () {
  const sequelize = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, dbConfig)

  const schema = {
    mixins: [DbService],
    // I added the option if noSync required with SqlAdapter(sequelize, 'noSync'),
    adapter: new SqlAdapter(sequelize),
    model: dbModel(sequelize, DataTypes),
  }

  return schema
}
`

I just changed the Connect method adding the option of 'noSync' in case is create with Sequelize instance and moved the modelReadyPromise after the model assignment.