### PR TITLE
feat: use sync option from sequelize config for disable/enable sync model

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -62,14 +62,14 @@ class SequelizeDbAdapter {
 			let modelDefinitionOrInstance = this.service.schema.model;
 
 			let noSync = false;
-			if (this.opts[3]) {
-				noSync = !!this.opts[3].noSync;
-			} else if (this.opts[0] && Object.prototype.hasOwnProperty.call(this.opts[0],"noSync")) {
+			if (this.opts[0] && Object.prototype.hasOwnProperty.call(this.opts[0],"noSync")) {
 				noSync = !!this.opts[0].noSync;
-			} else if (this.opts[3] && Object.prototype.hasOwnProperty.call(this.opts[3],"sync")) {
-				noSync = !this.opts[3].sync.force;
 			} else if (this.opts[0] && Object.prototype.hasOwnProperty.call(this.opts[0],"sync")) {
 				noSync = !this.opts[0].sync.force;
+			} else if (this.opts[3] && Object.prototype.hasOwnProperty.call(this.opts[3],"sync")) {
+				noSync = !this.opts[3].sync.force;
+			} else if (this.opts[3]) {
+				noSync = !!this.opts[3].noSync;
 			}
 
 			let modelReadyPromise;

--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -64,8 +64,12 @@ class SequelizeDbAdapter {
 			let noSync = false;
 			if (this.opts[3]) {
 				noSync = !!this.opts[3].noSync;
-			} else if (this.opts[0].dialect === "sqlite") {
+			} else if (this.opts[0] && Object.prototype.hasOwnProperty.call(this.opts[0],"noSync")) {
 				noSync = !!this.opts[0].noSync;
+			} else if (this.opts[3] && Object.prototype.hasOwnProperty.call(this.opts[3],"sync")) {
+				noSync = !this.opts[3].sync.force;
+			} else if (this.opts[0] && Object.prototype.hasOwnProperty.call(this.opts[0],"sync")) {
+				noSync = !this.opts[0].sync.force;
 			}
 
 			let modelReadyPromise;

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -482,5 +482,59 @@ describe("Test SequelizeAdapter", () => {
 			});
 		});
 	});
+
+	describe("sequelize config sync option set to false", () => {
+		const opts = {
+			dialect: "postgres",
+			sync: false
+		};
+		const adapter = new SequelizeAdapter(opts);
+
+		const broker = new ServiceBroker({ logger: false });
+		const service = broker.createService({
+			name: "store",
+			model: fakeModel
+		});
+		beforeEach(() => {
+			adapter.init(broker, service);
+		});
+
+		it("do not sync the model with database", () => {
+			return adapter.connect().catch(protectReject).then(() => {
+				expect(adapter.db).toBe(db);
+				expect(adapter.db.authenticate).toHaveBeenCalledTimes(1);
+				expect(adapter.db.define).toHaveBeenCalledTimes(1);
+
+				expect(adapter.model.sync).toHaveBeenCalledTimes(0);
+			});
+		});
+	});
+
+	describe("sequelize config sync option set to true", () => {
+		const opts = {
+			dialect: "postgres",
+			sync: { force: true }
+		};
+		const adapter = new SequelizeAdapter(opts);
+
+		const broker = new ServiceBroker({ logger: false });
+		const service = broker.createService({
+			name: "store",
+			model: fakeModel
+		});
+		beforeEach(() => {
+			adapter.init(broker, service);
+		});
+
+		it("sync the model with database", () => {
+			return adapter.connect().catch(protectReject).then(() => {
+				expect(adapter.db).toBe(db);
+				expect(adapter.db.authenticate).toHaveBeenCalledTimes(1);
+				expect(adapter.db.define).toHaveBeenCalledTimes(1);
+
+				expect(adapter.model.sync).toHaveBeenCalledTimes(1);
+			});
+		});
+	});
 });
 


### PR DESCRIPTION
Get sync option from sequelize connection config https://github.com/sequelize/sequelize/blob/5a807c514c00364d0fcd56ae682a06750c398df8/types/lib/sequelize.d.ts#L271

Useful when we have one config file for run migrations(https://sequelize.org/master/manual/migrations.html) and connect to db in molecular