### PR TITLE
Add support for searchFields parameter in the moleculer-db-adapter-mongoose

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -321,7 +321,7 @@ class MongooseDbAdapter {
 								[f]: new RegExp(params.search, "i")
 							}
 						))
-					})
+					});
 				} else {
 					// Full-text search
 					// More info: https://docs.mongodb.com/manual/reference/operator/query/text/

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -311,31 +311,43 @@ class MongooseDbAdapter {
 	createCursor(params) {
 		if (params) {
 			const q = this.model.find(params.query);
-			// Full-text search
-			// More info: https://docs.mongodb.com/manual/reference/operator/query/text/
+
+			// Search
 			if (_.isString(params.search) && params.search !== "") {
-				q.find({
-					$text: {
-						$search: params.search
-					}
-				});
-				q._fields = {
-					_score: {
-						$meta: "textScore"
-					}
-				};
-				q.sort({
-					_score: {
-						$meta: "textScore"
-					}
-				});
-			} else {
-				// Sort
-				if (_.isString(params.sort))
-					q.sort(params.sort.replace(/,/, " "));
-				else if (Array.isArray(params.sort))
-					q.sort(params.sort.join(" "));
+				if (params.searchFields && params.searchFields.length > 0) {
+					q.find({
+						$or: params.searchFields.map(f => (
+							{
+								[f]: new RegExp(params.search, "i")
+							}
+						))
+					})
+				} else {
+					// Full-text search
+					// More info: https://docs.mongodb.com/manual/reference/operator/query/text/
+					q.find({
+						$text: {
+							$search: params.search
+						}
+					});
+					q._fields = {
+						_score: {
+							$meta: "textScore"
+						}
+					};
+					q.sort({
+						_score: {
+							$meta: "textScore"
+						}
+					});
+				}
 			}
+
+			// Sort
+			if (_.isString(params.sort))
+				q.sort(params.sort.replace(/,/, " "));
+			else if (Array.isArray(params.sort))
+				q.sort(params.sort.join(" "));
 
 			// Offset
 			if (_.isNumber(params.offset) && params.offset > 0)

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -297,7 +297,16 @@ describe("Test MongooseStoreAdapter", () => {
 			expect(q.sort).toHaveBeenCalledWith({"_score": {"$meta": "textScore"}});
 			expect(q._fields).toEqual({"_score": {"$meta": "textScore"}});
 		});
+		
+		it("call with searchFields", () => {
+			adapter.model.find.mockClear();
+			let q = adapter.createCursor({ search: "walter", searchFields: ["name", "lastname"] });
+			expect(adapter.model.find).toHaveBeenCalledTimes(1);
+			expect(adapter.model.find).toHaveBeenCalledWith(undefined);
 
+			expect(q.find).toHaveBeenCalledTimes(1);
+			expect(q.find).toHaveBeenCalledWith({ "$or": [{ "name": /walter/i }, { "lastname": /walter/i }] });
+		})
 	});
 
 

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -306,7 +306,7 @@ describe("Test MongooseStoreAdapter", () => {
 
 			expect(q.find).toHaveBeenCalledTimes(1);
 			expect(q.find).toHaveBeenCalledWith({ "$or": [{ "name": /walter/i }, { "lastname": /walter/i }] });
-		})
+		});
 	});
 
 


### PR DESCRIPTION
When searchFields exists, do a "LIKE" search based on searchFields, when not, uses the full-text search based on index as it is currently. This would not break existing functionality, since without searchFields the search will work as it currently does and will allow the adapter to work like the others when searchFields is informed.

Related to #196