### PR TITLE
sequelize adaptor insertMany to accept an options object

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -200,12 +200,13 @@ class SequelizeDbAdapter {
 	 * Insert many entities
 	 *
 	 * @param {Array} entities
+	 * @param {Object} opts
 	 * @returns {Promise}
 	 *
 	 * @memberof SequelizeDbAdapter
 	 */
-	insertMany(entities) {
-		return this.model.bulkCreate(entities, { returning: true });
+	insertMany(entities, opts = { returning: true }) {
+		return this.model.bulkCreate(entities, opts);
 	}
 
 	/**

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -373,6 +373,17 @@ describe("Test SequelizeAdapter", () => {
 				expect(adapter.model.bulkCreate).toHaveBeenCalledWith(entities, { returning: true });
 			});
 		});
+		
+		it("call inserts with option param", () => {
+			adapter.model.create.mockClear();
+			let entities = [{ name: "John" }, { name: "Jane" }];
+			let opts = { ignoreDuplicates: true, returning: false }
+			
+			return adapter.insertMany(entities, opts).catch(protectReject).then(() => {
+				expect(adapter.model.bulkCreate).toHaveBeenCalledTimes(2);
+				expect(adapter.model.bulkCreate).toHaveBeenCalledWith(entities, opts);
+			});
+		});
 
 		it("call updateMany", () => {
 			let where = {};


### PR DESCRIPTION
Change method signature from `insertMany(entities)` to `insertMany(entities, opts = { returning: true })` to allow passing in of custom options, eg. `ignoreDuplicates`