### PR TITLE
fix connection error if there is more than one service

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/package-lock.json
+++ b/packages/moleculer-db-adapter-mongoose/package-lock.json
@@ -2251,9 +2251,9 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+			"integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
 			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -2346,9 +2346,9 @@
 			}
 		},
 		"bson": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+			"integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
 			"dev": true
 		},
 		"buffer-from": {
@@ -7037,12 +7037,12 @@
 			}
 		},
 		"mongodb": {
-			"version": "3.5.8",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.8.tgz",
-			"integrity": "sha512-jz7mR58z66JKL8Px4ZY+FXbgB7d0a0hEGCT7kw8iye46/gsqPrOEpZOswwJ2BQlfzsrCLKdsF9UcaUfGVN2HrQ==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+			"integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
 			"dev": true,
 			"requires": {
-				"bl": "^2.2.0",
+				"bl": "^2.2.1",
 				"bson": "^1.1.4",
 				"denque": "^1.4.1",
 				"require_optional": "^1.0.1",
@@ -7051,22 +7051,30 @@
 			}
 		},
 		"mongoose": {
-			"version": "5.9.18",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.18.tgz",
-			"integrity": "sha512-agZbIuQcN1gZ12BJn6KesA+bgsvoLVjCwhfPw88hggxX8O24SWK4EJwN35GEZKDej9AHUZKNAPgmdeXCVQxviA==",
+			"version": "5.10.5",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.5.tgz",
+			"integrity": "sha512-BOQZsZn9Y79f3rWZFLD1gvOLNN5gOiGvGr5raqQ5v/T4fdAmnjXGCVynpW4SRnQLtrcCeLXyaaXVRT75863Q0w==",
 			"dev": true,
 			"requires": {
 				"bson": "^1.1.4",
 				"kareem": "2.3.1",
-				"mongodb": "3.5.8",
+				"mongodb": "3.6.2",
 				"mongoose-legacy-pluralize": "1.0.2",
 				"mpath": "0.7.0",
 				"mquery": "3.2.2",
 				"ms": "2.1.2",
 				"regexp-clone": "1.0.0",
-				"safe-buffer": "5.1.2",
+				"safe-buffer": "5.2.1",
 				"sift": "7.0.1",
 				"sliced": "1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				}
 			}
 		},
 		"mongoose-legacy-pluralize": {
@@ -9528,7 +9536,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {

--- a/packages/moleculer-db-adapter-mongoose/package.json
+++ b/packages/moleculer-db-adapter-mongoose/package.json
@@ -36,7 +36,7 @@
     "jest-cli": "^26.0.1",
     "lolex": "^6.0.0",
     "moleculer": "^0.14.7",
-    "mongoose": "^5.9.18",
+    "mongoose": "^5.10.5",
     "nodemon": "^2.0.4",
     "npm-check": "^5.9.2"
   },

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -83,7 +83,8 @@ class MongooseDbAdapter {
 			this.model = conn.model(this.modelName, this.schema);
 		}
 
-		return conn.then(result => {
+		return conn.then(_result => {
+			const result = _result || conn
 			this.conn = conn;
 
 			if (result.connection)


### PR DESCRIPTION
Fix this issue #221 

### Why?

When using mongoose v5.10.1 or later, we will get this error if there is more than one service.
Probably caused by this commit: [Automattic/mongoose@fadc813](https://github.com/Automattic/mongoose/commit/fadc813eaa32dd357e93beb8614de35e5f346600) - [History.md](https://github.com/Automattic/mongoose/blob/master/History.md#5101--2020-08-26)


To reproduce the error, I am using mongoose v5.10.5 and run `npm run dev moleculer-db-adapter-mongoose populates`. 

Result:

```
...
[2020-09-17T16:12:48.051Z] INFO desktop-4eps3u4-13761/POSTS: MongoDB adapter has connected successfully.
[2020-09-17T16:12:48.052Z] ERROR desktop-4eps3u4-13761/USERS: Connection error! TypeError: Cannot read property 'connection' of undefined
at /home/ubuntu/projects/moleculer-db/packages/moleculer-db-adapter-mongoose/src/index.js:89:15
at tryCatcher (/home/ubuntu/projects/moleculer-db/packages/moleculer-db-adapter-mongoose/node_modules/bluebird/js/release/util.js:16:23)
...
```

### How did I fix it?

At line `86`, the `result` variable will be `undefined` after first connection. I have set `result = conn` if it's undefined.

