### PR TITLE
feat: allow to specify resulting populated field name

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -624,16 +624,16 @@ module.exports = {
 				let arr = Array.isArray(docs) ? docs : [docs];
 
 				// Collect IDs from field of docs (flatten, compact & unique list)
-				let idList = _.uniq(_.flattenDeep(_.compact(arr.map(doc => _.get(doc, field)))));
+				let idList = _.uniq(_.flattenDeep(_.compact(arr.map(doc => _.get(doc, rule.field)))));
 				// Replace the received models according to IDs in the original docs
 				const resultTransform = (populatedDocs) => {
 					arr.forEach(doc => {
-						let id = _.get(doc, field);
+						let id = _.get(doc, rule.field);
 						if (_.isArray(id)) {
 							let models = _.compact(id.map(id => populatedDocs[id]));
-							_.set(doc, rule.field, models);
+							_.set(doc, field, models);
 						} else {
-							_.set(doc, rule.field, populatedDocs[id]);
+							_.set(doc, field, populatedDocs[id]);
 						}
 					});
 				};

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -618,7 +618,8 @@ module.exports = {
 						action: rule
 					};
 				}
-				rule.field = field;
+
+				if (rule.field === undefined) rule.field = field;
 
 				let arr = Array.isArray(docs) ? docs : [docs];
 
@@ -630,9 +631,9 @@ module.exports = {
 						let id = _.get(doc, field);
 						if (_.isArray(id)) {
 							let models = _.compact(id.map(id => populatedDocs[id]));
-							_.set(doc, field, models);
+							_.set(doc, rule.field, models);
 						} else {
-							_.set(doc, field, populatedDocs[id]);
+							_.set(doc, rule.field, populatedDocs[id]);
 						}
 					});
 				};

--- a/packages/moleculer-db/test/integration/populates.spec.js
+++ b/packages/moleculer-db/test/integration/populates.spec.js
@@ -24,7 +24,7 @@ describe("Test populates feature", () => {
 		name: "posts",
 		adapter: new Adapter(),
 		settings: {
-			fields: ["_id", "title", "content", "author","reviewer", "reviewerId"],
+			fields: ["_id", "title", "content", "author", "reviewer", "reviewerId"],
 			populates: {
 				author: {
 					action: "users.get"
@@ -132,6 +132,4 @@ describe("Test populates feature", () => {
 			});
 		});
 	});
-
-
 });

--- a/packages/moleculer-db/test/integration/populates.spec.js
+++ b/packages/moleculer-db/test/integration/populates.spec.js
@@ -29,8 +29,8 @@ describe("Test populates feature", () => {
 				author: {
 					action: "users.get"
 				},
-				reviewerId: {
-					field: "reviewer",
+				reviewer: {
+					field: "reviewerId",
 					action: "users.get"
 				}
 			}
@@ -121,7 +121,7 @@ describe("Test populates feature", () => {
 	});
 
 	it("should return with the entity and populate the review instead of reviewerId", () => {
-		return broker.call("posts.get", { id: posts[0]._id, populate: ["author","reviewerId"] }).catch(protectReject).then(res => {
+		return broker.call("posts.get", { id: posts[0]._id, populate: ["author","reviewer"] }).catch(protectReject).then(res => {
 			expect(res).toEqual({
 				"_id": posts[0]._id,
 				"author": {"_id": users[2]._id, "name": "Walter", "username": "walter"},

--- a/packages/moleculer-db/test/integration/populates.spec.js
+++ b/packages/moleculer-db/test/integration/populates.spec.js
@@ -7,7 +7,7 @@ const Adapter = require("../../src/memory-adapter");
 function protectReject(err) {
 	if (err && err.stack) {
 		console.error(err);
-		console.error(err.stack);	
+		console.error(err.stack);
 	}
 	expect(err).toBe(true);
 }
@@ -24,9 +24,13 @@ describe("Test populates feature", () => {
 		name: "posts",
 		adapter: new Adapter(),
 		settings: {
-			fields: ["_id", "title", "content", "author"],
+			fields: ["_id", "title", "content", "author","reviewer", "reviewerId"],
 			populates: {
 				author: {
+					action: "users.get"
+				},
+				reviewerId: {
+					field: "reviewer",
 					action: "users.get"
 				}
 			}
@@ -59,8 +63,12 @@ describe("Test populates feature", () => {
 				res.forEach((e, i) => users[i]._id = e._id);
 
 				posts[0].author = res[2]._id;
+				posts[0].reviewerId = res[0]._id;
 				posts[1].author = res[0]._id;
+				posts[1].reviewerId = res[0]._id;
 				posts[2].author = res[1]._id;
+				posts[2].reviewerId = res[0]._id;
+
 
 				return broker.call("posts.insert", { entities: posts }).then(res => {
 					res.forEach((e, i) => posts[i]._id = e._id);
@@ -69,46 +77,61 @@ describe("Test populates feature", () => {
 
 		});
 	});
-	
+
 	it("should return with count of entities", () => {
 		return broker.call("posts.count").catch(protectReject).then(res => {
 			expect(res).toBe(3);
 		});
 	});
 
-	it("should return with the entity and populate the author", () => {
+	it("should return with the entity and populate the author, reviewerId", () => {
 		return broker.call("posts.get", { id: posts[0]._id, populate: ["author"] }).catch(protectReject).then(res => {
 			expect(res).toEqual({
-				"_id": posts[0]._id, 
-				"author": {"_id": users[2]._id, "name": "Walter", "username": "walter"}, 
-				"content": "This is the content", 
-				"title": "My first post"
+				"_id": posts[0]._id,
+				"author": {"_id": users[2]._id, "name": "Walter", "username": "walter"},
+				"content": "This is the content",
+				"title": "My first post",
+				"reviewerId": users[0]._id
 			});
 		});
 	});
 
 	it("should return with multiple entities by IDs", () => {
-		return broker.call("posts.get", { 
-			id: [posts[2]._id, posts[0]._id], 
-			populate: ["author"], 
-			fields: ["title", "author.name"] 
+		return broker.call("posts.get", {
+			id: [posts[2]._id, posts[0]._id],
+			populate: ["author"],
+			fields: ["title", "author.name"]
 		}).catch(protectReject).then(res => {
 			expect(res).toEqual([
-				{"author": {"name": "Jane"}, "title": "My last post"}, 
+				{"author": {"name": "Jane"}, "title": "My last post"},
 				{"author": {"name": "Walter"}, "title": "My first post"}
 			]);
 		});
 	});
 
 	it("should return with multiple entities as Object", () => {
-		return broker.call("posts.get", { 
-			id: [posts[2]._id, posts[0]._id], 
-			fields: ["title", "votes"], 
-			mapping: true 
+		return broker.call("posts.get", {
+			id: [posts[2]._id, posts[0]._id],
+			fields: ["title", "votes"],
+			mapping: true
 		}).catch(protectReject).then(res => {
-			expect(res[posts[0]._id]).toEqual({"title": "My first post"}); 
-			expect(res[posts[2]._id]).toEqual({"title": "My last post"}); 
+			expect(res[posts[0]._id]).toEqual({"title": "My first post"});
+			expect(res[posts[2]._id]).toEqual({"title": "My last post"});
 		});
 	});
 
-});	
+	it("should return with the entity and populate the review instead of reviewerId", () => {
+		return broker.call("posts.get", { id: posts[0]._id, populate: ["author","reviewerId"] }).catch(protectReject).then(res => {
+			expect(res).toEqual({
+				"_id": posts[0]._id,
+				"author": {"_id": users[2]._id, "name": "Walter", "username": "walter"},
+				"reviewerId":users[0]._id,
+				"reviewer": {"_id": users[0]._id, "name": users[0].name, "username":users[0].username},
+				"content": "This is the content",
+				"title": "My first post"
+			});
+		});
+	});
+
+
+});


### PR DESCRIPTION
I would like to add this feature that allows to specify the resulting populated field name

```
name: "posts",
		adapter: new Adapter(),
		settings: {
			fields: ["_id", "title", "content", "author","reviewer", "reviewerId"],
			populates: {
				author: {
					action: "users.get"
				},
				reviewerId: {
					field: "reviewer",
					action: "users.get"
				}
			}
		}
```
Instead of replacing reviewerId by the resulting populated object, a new field "reviewer" will be added that contains the populated object.

The reason for this feature is that when replacing the original reviewerId field it breaks the contract towards depending services.
Depending services would expect a field reviewerId which contains the reviewer Id as string.
If the reviewerId field is replace by an object, depending service will break on this.

solves issue #223