### PR TITLE
[hacktoberfest] Close Sequelize before connection error

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/package-lock.json
+++ b/packages/moleculer-db-adapter-sequelize/package-lock.json
@@ -1805,6 +1805,131 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
+		"@types/jest": {
+			"version": "26.0.14",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
+			"integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+			"dev": true,
+			"requires": {
+				"jest-diff": "^25.2.1",
+				"pretty-format": "^25.2.1"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+					"integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^3.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+					"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*",
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+					"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-diff": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+					"integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+					"dev": true,
+					"requires": {
+						"chalk": "^3.0.0",
+						"diff-sequences": "^25.2.6",
+						"jest-get-type": "^25.2.6",
+						"pretty-format": "^25.5.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "25.2.6",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+					"integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "25.5.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+					"integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^25.5.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"@types/node": {
 			"version": "14.0.11",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.11.tgz",

--- a/packages/moleculer-db-adapter-sequelize/package.json
+++ b/packages/moleculer-db-adapter-sequelize/package.json
@@ -30,6 +30,7 @@
     "sequelize": "^5.9.4"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.14",
     "benchmarkify": "^2.1.2",
     "coveralls": "^3.1.0",
     "eslint": "^7.10.0",

--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -87,6 +87,9 @@ class SequelizeDbAdapter {
 
 			return modelReadyPromise.then(() => {
 				this.service.logger.info("Sequelize adapter has connected successfully.");
+			}).catch((e) => {
+				return this.db.close()
+					.finally(() => Promise.reject(e));
 			});
 		});
 	}

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -128,6 +128,19 @@ describe("Test SequelizeAdapter", () => {
 			});
 		});
 
+		it("should disconnect after connection error", () => {
+			let hasThrown = true;
+			model.sync.mockImplementationOnce(() => Promise.reject());
+			return adapter.connect()
+				.then(() => {
+					hasThrown = false;
+				})
+				.catch(() => {
+					expect(hasThrown).toBe(true);
+					expect(adapter.db.close).toBeCalledTimes(1);
+				});
+		});
+
 		it("call disconnect", () => {
 			adapter.db.close.mockClear();
 
@@ -377,7 +390,7 @@ describe("Test SequelizeAdapter", () => {
 		it("call inserts with option param", () => {
 			adapter.model.create.mockClear();
 			let entities = [{ name: "John" }, { name: "Jane" }];
-			let opts = { ignoreDuplicates: true, returning: false }
+			let opts = { ignoreDuplicates: true, returning: false };
 			
 			return adapter.insertMany(entities, opts).catch(protectReject).then(() => {
 				expect(adapter.model.bulkCreate).toHaveBeenCalledTimes(2);
@@ -524,6 +537,7 @@ describe("Test SequelizeAdapter", () => {
 			return adapter.connect().catch(protectReject).then(() => {
 				expect(Sequelize).toHaveBeenCalledTimes(1);
 				expect(Sequelize).toHaveBeenCalledWith(opts);
+				expect(adapter.db).toBe(opts);
 				expect(adapter.db).toBe(db);
 				expect(adapter.db.authenticate).toHaveBeenCalledTimes(1);
 				expect(adapter.db.define).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
## Relative to
This PR is relative to the issue #227.

## Purpose of the PR
Trying to solving the issue highlighted by #227 : with this PR, after a connection error inside the Sequelize adapter, the Sequelize instance is shot down avoiding creating memory leaks for unreferenced database connections and avoiding too many connections to the database itself when retrying.

## Added test
Added one new test for checking if the Sequelize.close gets closed after an instantiation error is thrown.

## Miscellanea
Added @types/jest in dev dependencies.
