### PR TITLE
fix missing limit when directly call this._list(ctx, params)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3815,6 +3815,15 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "binary-search-tree": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
+      "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
+      "dev": true,
+      "requires": {
+        "underscore": "~1.4.4"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -7063,6 +7072,12 @@
         }
       }
     },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -8531,6 +8546,12 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -10852,6 +10873,15 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dev": true,
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -10931,6 +10961,15 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
+      }
+    },
+    "localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -12545,6 +12584,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nedb": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
+      "integrity": "sha1-DjUCzYLABNU1WkPJ5VV3vXvZHYg=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "binary-search-tree": "0.2.5",
+        "localforage": "^1.3.0",
+        "mkdirp": "~0.5.1",
+        "underscore": "~1.4.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
+      }
     },
     "neo-async": {
       "version": "2.6.1",
@@ -16576,6 +16636,12 @@
           "dev": true
         }
       }
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "coveralls": "^3.1.0",
     "eslint": "^7.2.0",
+    "flat": "^5.0.2",
     "glob": "^7.1.6",
     "jest": "^26.0.1",
     "jest-cli": "^26.0.1",
@@ -34,6 +35,7 @@
     "lodash": "^4.17.15",
     "markdown-magic": "^0.1.25",
     "moleculer": "^0.14.7",
+    "nedb": "^1.8.0",
     "nodemon": "^2.0.4",
     "npm-check": "^5.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "coveralls": "^3.1.0",
     "eslint": "^7.2.0",
-    "flat": "^5.0.2",
     "glob": "^7.1.6",
     "jest": "^26.0.1",
     "jest-cli": "^26.0.1",
@@ -35,7 +34,6 @@
     "lodash": "^4.17.15",
     "markdown-magic": "^0.1.25",
     "moleculer": "^0.14.7",
-    "nedb": "^1.8.0",
     "nodemon": "^2.0.4",
     "npm-check": "^5.9.2"
   },

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -8,7 +8,7 @@
 
 const _ = require("lodash");
 const Promise = require("bluebird");
-const { flatten } = require('flat');
+const { flatten } = require("flat");
 const { MoleculerClientError, ValidationError } = require("moleculer").Errors;
 const { EntityNotFoundError } = require("./errors");
 const MemoryAdapter = require("./memory-adapter");

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -742,6 +742,12 @@ module.exports = {
 				countParams.limit = null;
 			if (countParams && countParams.offset)
 				countParams.offset = null;
+			if (params.limit == null) {
+				if (this.settings.limit > 0 && params.pageSize > this.settings.limit)
+					params.limit = this.settings.limit;
+				else
+					params.limit = params.pageSize;
+			}
 			return Promise.all([
 				// Get rows
 				this.adapter.find(params),


### PR DESCRIPTION
when call throw action list, the params is passed `sanitizeParams` that correct `params.limit`, after that, params will be sent to `adapter.find` but if we make directly call `this._list` method, params was not done properly and missing `limit` property.
this pull fix this problem
more fixes:
~~+ missing flat, nedb packages that prevent me running test~~
+ eslint check `'flat'` to `"flat"`