### PR TITLE
fix mongoose stuck after broker.stop called

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -84,7 +84,7 @@ class MongooseDbAdapter {
 		}
 
 		return conn.then(_result => {
-			const result = _result || conn
+			const result = _result || conn;
 			this.conn = conn;
 
 			if (result.connection)
@@ -112,6 +112,8 @@ class MongooseDbAdapter {
 		return new Promise(resolve => {
 			if (this.db && this.db.close) {
 				this.db.close(resolve);
+			} else if (this.conn && this.conn.close) {
+				this.conn.close(resolve);
 			} else {
 				mongoose.connection.close(resolve);
 			}


### PR DESCRIPTION
`mongoose.connection` always point to `mongoose.connections[0]` so if we call sth likes
```js
return {
  mixins: [DbService],
  adapter: new MongoAdapter('mongodb://127.0.0.1') // new connection was created each service
}
```
we can not disconnect correctly (because we just stop first connection)
this pull fix this problem