### PR TITLE
fix bug when disconnect call before successfully connected

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -79,7 +79,7 @@ class MongooseDbAdapter {
 					return mongoose.connection;
 				} else if (mongoose.connection.readyState === 2) {
 					return new Promise((resolve, reject) => {
-						mongoose.connection.once("connected", resolve(mongoose.connection));
+						mongoose.connection.once("connected", () => resolve(mongoose.connection));
 						mongoose.connection.once("error", reject);
 					});
 				} else {

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -97,16 +97,15 @@ class MongooseDbAdapter {
 					}).catch(reject);
 				}
 			} else if (this.schema) {
-				// if service's schema only has schema field type, not model, we must do connect manually
-				const conn = mongoose.createConnection(this.uri, this.opts);
-				conn.once("connected", () => {
-					// init model and return connection
-					this.model = conn.model(this.modelName, this.schema);
-					resolve(conn);
-				});
-				conn.on("error", reject);
+				// note: do not use sth likes mongoose.createConnection().then()/*.catch()*/ here, some cases will trigger bluebird warning
+				// https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
+				resolve(mongoose.createConnection(this.uri, this.opts));
 			}
 		}).then(conn => {
+			if (this.model == null && this.schema) {
+				// if service's schema only has schema field type, not model, init model and return connection
+				this.model = conn.model(this.modelName, this.schema);
+			}
 			this.conn = conn;
 
 			if (this.conn.constructor.name === "Db") {

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -25,7 +25,7 @@ class MongooseDbAdapter {
 	 * @memberof MongooseDbAdapter
 	 */
 	constructor(uri, opts) {
-		this.uri = uri,
+		this.uri = uri;
 		this.opts = opts;
 		mongoose.Promise = Promise;
 	}
@@ -308,7 +308,7 @@ class MongooseDbAdapter {
 	 * 	- offset
 	 *  - query
 	 *
- 	 * @param {Object} params
+	 * @param {Object} params
 	 * @returns {MongoQuery}
 	 */
 	createCursor(params) {
@@ -366,12 +366,12 @@ class MongooseDbAdapter {
 	}
 
 	/**
-	* Transforms 'idField' into MongoDB's '_id'
-	* @param {Object} entity
-	* @param {String} idField
-	* @memberof MongoDbAdapter
-	* @returns {Object} Modified entity
-	*/
+	 * Transforms 'idField' into MongoDB's '_id'
+	 * @param {Object} entity
+	 * @param {String} idField
+	 * @memberof MongoDbAdapter
+	 * @returns {Object} Modified entity
+	 */
 	beforeSaveTransformID (entity, idField) {
 		let newEntity = _.cloneDeep(entity);
 
@@ -384,12 +384,12 @@ class MongooseDbAdapter {
 	}
 
 	/**
-	* Transforms MongoDB's '_id' into user defined 'idField'
-	* @param {Object} entity
-	* @param {String} idField
-	* @memberof MongoDbAdapter
-	* @returns {Object} Modified entity
-	*/
+	 * Transforms MongoDB's '_id' into user defined 'idField'
+	 * @param {Object} entity
+	 * @param {String} idField
+	 * @memberof MongoDbAdapter
+	 * @returns {Object} Modified entity
+	 */
 	afterRetrieveTransformID (entity, idField) {
 		if (idField !== "_id") {
 			entity[idField] = this.objectIDToString(entity["_id"]);
@@ -399,11 +399,11 @@ class MongooseDbAdapter {
 	}
 
 	/**
-	* Convert hex string to ObjectID
-	* @param {String} id
-	* @returns ObjectID}
-	* @memberof MongooseDbAdapter
-	*/
+	 * Convert hex string to ObjectID
+	 * @param {String} id
+	 * @returns ObjectID}
+	 * @memberof MongooseDbAdapter
+	 */
 	stringToObjectID (id) {
 		if (typeof id == "string" && mongoose.Types.ObjectId.isValid(id))
 			return new mongoose.Schema.Types.ObjectId(id);
@@ -411,11 +411,11 @@ class MongooseDbAdapter {
 	}
 
 	/**
-	* Convert ObjectID to hex string
-	* @param {ObjectID} id
-	* @returns {String}
-	* @memberof MongooseDbAdapter
-	*/
+	 * Convert ObjectID to hex string
+	 * @param {ObjectID} id
+	 * @returns {String}
+	 * @memberof MongooseDbAdapter
+	 */
 	objectIDToString (id) {
 		if(id && id.toString)
 			return id.toString();


### PR DESCRIPTION
while using jest to test my service with real `mongodb`, I still got stuck with mongoose connection likes pull #233, which should be fixed. After researching, I found that while running tests, `broker.stop()` was called before mongodb connect successfully. In this case, `this.conn` is not `undefined` but `this.conn.close` (same with `this.conn.db`) still not created.
This pull changes something:
~~[x] remove `this.db`, I don't understand why we need this?~~
[x] adapter connection will be set to `this.conn`
[x] rewrite tests