### PR TITLE
Use preconfigured Nedb Datastore instead of creating one

### DIFF
--- a/packages/moleculer-db/package.json
+++ b/packages/moleculer-db/package.json
@@ -55,6 +55,6 @@
     "bluebird": "^3.7.2",
     "flat": "^5.0.2",
     "lodash": "^4.17.20",
-    "nedb": "https://github.com/mbasunov/nedb.git"
+    "nedb": "https://github.com/cintolas/nedb.git"
   }
 }

--- a/packages/moleculer-db/package.json
+++ b/packages/moleculer-db/package.json
@@ -55,6 +55,6 @@
     "bluebird": "^3.7.2",
     "flat": "^5.0.2",
     "lodash": "^4.17.20",
-    "nedb": "^1.8.0"
+    "nedb": "https://github.com/mbasunov/nedb.git"
   }
 }

--- a/packages/moleculer-db/package.json
+++ b/packages/moleculer-db/package.json
@@ -55,6 +55,6 @@
     "bluebird": "^3.7.2",
     "flat": "^5.0.2",
     "lodash": "^4.17.20",
-    "nedb": "https://github.com/cintolas/nedb.git"
+    "nedb": "https://github.com/mbasunov/nedb.git"
   }
 }

--- a/packages/moleculer-db/package.json
+++ b/packages/moleculer-db/package.json
@@ -55,6 +55,6 @@
     "bluebird": "^3.7.2",
     "flat": "^5.0.2",
     "lodash": "^4.17.20",
-    "nedb": "https://github.com/mbasunov/nedb.git"
+    "nedb": "^1.8.0"
   }
 }

--- a/packages/moleculer-db/src/memory-adapter.js
+++ b/packages/moleculer-db/src/memory-adapter.js
@@ -46,7 +46,10 @@ class MemoryDbAdapter {
 	 * @memberof MemoryDbAdapter
 	 */
 	connect() {
-		this.db = new Datastore(this.opts); // in-memory
+		if(this.opts instanceof Datastore)
+			this.db = this.opts; //use preconfigured datastore
+		else
+			this.db = new Datastore(this.opts); // in-memory
 
 		["loadDatabase", "insert", "findOne", "count", "remove", "ensureIndex", "removeIndex"].forEach(method => {
 			this.db[method] = Promise.promisify(this.db[method]);

--- a/packages/moleculer-db/test/unit/memory-adapter.spec.js
+++ b/packages/moleculer-db/test/unit/memory-adapter.spec.js
@@ -3,6 +3,7 @@
 const { ServiceBroker } = require("moleculer");
 const Adapter = require("../../src/memory-adapter");
 
+const Datastore = require('nedb');
 
 function protectReject(err) {
 	if (err && err.stack) {
@@ -24,6 +25,15 @@ describe("Test Adapter constructor", () => {
 		expect(adapter).toBeDefined();
 		expect(adapter.opts).toBe(opts);
 	});
+
+	it('should use preconfigured Datastore', () => {
+		const ds = new Datastore();
+		const adapter = new Adapter(ds);
+		adapter.connect();
+		expect(adapter).toBeDefined();
+		expect(adapter.db).toBe(ds);
+	});
+	
 });
 
 describe("Test Adapter methods", () => {


### PR DESCRIPTION
Allow MemoryAdapter to use a datastore that already exists instead of creating one during the connect call