### PR TITLE
allow 12 character _ids to be processed

### DIFF
--- a/packages/moleculer-db-adapter-mongo/src/index.js
+++ b/packages/moleculer-db-adapter-mongo/src/index.js
@@ -359,7 +359,7 @@ class MongoDbAdapter {
 	 * @memberof MongoDbAdapter
 	 */
 	stringToObjectID(id) {
-		if (typeof id == "string" && ObjectID.isValid(id))
+		if (typeof id == "string" && !isNaN(parseInt(id,16)) && ObjectID.isValid(id))
 			return new ObjectID.createFromHexString(id);
 
 		return id;


### PR DESCRIPTION
if you had a _id string that was 12 characters long and not hex, it would fail as its not a hex string.  If it is not an actual hex string fall back to the other method