### PR TITLE
Updated Imports in typings file

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/index.d.ts
+++ b/packages/moleculer-db-adapter-mongoose/index.d.ts
@@ -1,7 +1,6 @@
 declare module "moleculer-db-adapter-mongoose" {
 	import { Service, ServiceBroker } from "moleculer";
 	import {
-		ConnectionBase,
 		ConnectionOptions,
 		Document,
 		DocumentQuery,

--- a/packages/moleculer-db-adapter-mongoose/index.d.ts
+++ b/packages/moleculer-db-adapter-mongoose/index.d.ts
@@ -3,7 +3,7 @@ declare module "moleculer-db-adapter-mongoose" {
 	import {
 		ConnectionOptions,
 		Document,
-		DocumentQuery,
+		Query as DocumentQuery, //reff: https://github.com/Automattic/mongoose/issues/10036#issuecomment-803144616
 		Model,
 		Schema
 	} from "mongoose";


### PR DESCRIPTION
Removed unused import from ```moleculer-db-adapter-mongoose``` typings file, was giving an error in my environment where I don't generate code until code is completely clean.