### PR TITLE
Update moleculer-db-adapter-mongoose type define

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/index.d.ts
+++ b/packages/moleculer-db-adapter-mongoose/index.d.ts
@@ -149,6 +149,16 @@ declare module "moleculer-db-adapter-mongoose" {
 		createCursor(
 			params: FindFilters
 		): DocumentQuery<TDocument[], TDocument>;
+		
+		/**
+		 * Transforms 'idField' into MongoDB's '_id'
+		 */
+		beforeSaveTransformID(entity: object, idField: string): object;
+
+		/**
+		 * Transforms MongoDB's '_id' into user defined 'idField'
+		 */
+		afterRetrieveTransformID(entity: object, idField: string): object;
 	}
 	export = MongooseDbAdapter;
 }


### PR DESCRIPTION
`MongooseDbAdapter` should match with `DbAdapter` in `moleculer-db`

Usage:
```typescript
import type { MoleculerDB } from 'moleculer-db';
import type MongooseDbAdapter from 'moleculer-db-adapter-mongoose';
import type { Document } from 'mongoose';
type Type = MoleculerDB<MongooseDbAdapter<Document>>;
```