### PR TITLE
Remove useless code in moleculer-db-adapter-mongoose tsd

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/index.d.ts
+++ b/packages/moleculer-db-adapter-mongoose/index.d.ts
@@ -1,12 +1,11 @@
 declare module "moleculer-db-adapter-mongoose" {
 	import { Service, ServiceBroker } from "moleculer";
 	import {
-		ConnectionBase,
 		ConnectionOptions,
 		Document,
 		DocumentQuery,
 		Model,
-		Schema
+		Schema,
 	} from "mongoose";
 	import { Db } from "mongodb";
 
@@ -149,7 +148,7 @@ declare module "moleculer-db-adapter-mongoose" {
 		createCursor(
 			params: FindFilters
 		): DocumentQuery<TDocument[], TDocument>;
-		
+
 		/**
 		 * Transforms 'idField' into MongoDB's '_id'
 		 */


### PR DESCRIPTION
`ConnectionBase` in mongoose .d.ts file is not use or export
And in special, mongoose not export this in latest version.

If user install latest mongoose, it have a type error

Reference: https://github.com/Automattic/mongoose/blob/master/index.d.ts