### PR TITLE
remove unnecessary sanitizeParams

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -240,8 +240,7 @@ module.exports = {
 				entities: { type: "array", optional: true }
 			},
 			handler(ctx) {
-				let params = this.sanitizeParams(ctx, ctx.params);
-				return this._insert(ctx, params);
+				return this._insert(ctx, ctx.params);
 			}
 		},
 
@@ -302,8 +301,7 @@ module.exports = {
 		update: {
 			rest: "PUT /:id",
 			handler(ctx) {
-				let params = ctx.params;
-				return this._update(ctx, params);
+				return this._update(ctx, ctx.params);
 			}
 		},
 
@@ -323,8 +321,7 @@ module.exports = {
 				id: { type: "any" }
 			},
 			handler(ctx) {
-				let params = this.sanitizeParams(ctx, ctx.params);
-				return this._remove(ctx, params);
+				return this._remove(ctx, ctx.params);
 			}
 		}
 	},

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -219,8 +219,7 @@ module.exports = {
 		create: {
 			rest: "POST /",
 			handler(ctx) {
-				let params = ctx.params;
-				return this._create(ctx, params);
+				return this._create(ctx, ctx.params);
 			}
 		},
 

--- a/packages/moleculer-db/test/unit/index.actions.spec.js
+++ b/packages/moleculer-db/test/unit/index.actions.spec.js
@@ -171,8 +171,8 @@ describe("Test DbService actions", () => {
 		const p = { name: "John Smith", age: 45 };
 
 		return broker.call("store.insert", p).catch(protectReject).then(ctx => {
-			expect(service.sanitizeParams).toHaveBeenCalledTimes(1);
-			expect(service.sanitizeParams).toHaveBeenCalledWith(ctx, p);
+			// expect(service.sanitizeParams).toHaveBeenCalledTimes(1);
+			// expect(service.sanitizeParams).toHaveBeenCalledWith(ctx, p);
 
 			expect(service._insert).toHaveBeenCalledTimes(1);
 			expect(service._insert).toHaveBeenCalledWith(ctx, p);
@@ -209,8 +209,8 @@ describe("Test DbService actions", () => {
 		const p = { id: 1 };
 
 		return broker.call("store.remove", p).catch(protectReject).then(ctx => {
-			expect(service.sanitizeParams).toHaveBeenCalledTimes(1);
-			expect(service.sanitizeParams).toHaveBeenCalledWith(ctx, p);
+			// expect(service.sanitizeParams).toHaveBeenCalledTimes(1);
+			// expect(service.sanitizeParams).toHaveBeenCalledWith(ctx, p);
 
 			expect(service._remove).toHaveBeenCalledTimes(1);
 			expect(service._remove).toHaveBeenCalledWith(ctx, p);


### PR DESCRIPTION
call `sanitizeParams` is unnecessary for `insert` and `remove`