### PR TITLE
fix: count just the right number of row

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -302,9 +302,10 @@ class SequelizeDbAdapter {
 	 * @returns {Promise}
 	 */
 	createCursor(params, isCounting) {
+		const strictCountRule = { distinct: true, col: `${this.model.tableName}.${this.model.primaryKeyAttribute}` };
 		if (!params) {
 			if (isCounting)
-				return this.model.count();
+				return this.model.count(strictCountRule);
 
 			return this.model.findAll();
 		}
@@ -356,7 +357,7 @@ class SequelizeDbAdapter {
 			q.limit = params.limit;
 
 		if (isCounting)
-			return this.model.count(q);
+			return this.model.count(_.merge(q, strictCountRule));
 
 		return this.model.findAll(q);
 	}

--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -302,7 +302,7 @@ class SequelizeDbAdapter {
 	 * @returns {Promise}
 	 */
 	createCursor(params, isCounting) {
-		const strictCountRule = { distinct: true, col: `${this.model.tableName}.${this.model.primaryKeyAttribute}` };
+		const strictCountRule = { distinct: true, col: `${this.model.name ||this.model.tableName}.${this.model.primaryKeyAttribute}` };
 		if (!params) {
 			if (isCounting)
 				return this.model.count(strictCountRule);

--- a/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-sequelize/test/unit/index.spec.js
@@ -5,6 +5,8 @@ const { ServiceBroker } = require("moleculer");
 jest.mock("sequelize");
 
 const model = {
+	tableName: "posts",
+	primaryKeyAttribute: 'id',
 	sync: jest.fn(() => Promise.resolve()),
 	findAll: jest.fn(() => Promise.resolve()),
 	count: jest.fn(() => Promise.resolve()),
@@ -40,6 +42,7 @@ function protectReject(err) {
 const fakeModel = {
 	name: "posts",
 	define: {
+		id: { type: "number", primaryKey: true },
 		a: 5
 	},
 	options: {
@@ -163,7 +166,10 @@ describe("Test SequelizeAdapter", () => {
 				adapter.model.findAll.mockClear();
 				adapter.createCursor(null, true);
 				expect(adapter.model.count).toHaveBeenCalledTimes(1);
-				expect(adapter.model.count).toHaveBeenCalledWith();
+				expect(adapter.model.count).toHaveBeenCalledWith({
+					distinct: true,
+					col: `${model.tableName}.${model.primaryKeyAttribute}`
+				});
 			});
 
 			it("call with query", () => {
@@ -179,7 +185,11 @@ describe("Test SequelizeAdapter", () => {
 				let query = {};
 				adapter.createCursor({ query }, true);
 				expect(adapter.model.count).toHaveBeenCalledTimes(1);
-				expect(adapter.model.count).toHaveBeenCalledWith({ where: query });
+				expect(adapter.model.count).toHaveBeenCalledWith({
+					distinct: true,
+					col: `${model.tableName}.${model.primaryKeyAttribute}`,
+					where: query
+				});
 			});
 
 			it("call with sort string", () => {


### PR DESCRIPTION
Apply a more explicit count of data for the pagination, normally there's no problem but when doing an ```include``` in the default scope will be counted the included data for each record. For example:

By having those two models

```js
let User = sequelize.define("users",
    {
      id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
      username: { type: DataTypes.STRING }
    }, { paranoid: true }
);
```

```js
let Auth = sequelize.define("auths",
    {
      id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
      name: { type: DataTypes.STRING }
    }, { paranoid: false }
);
```

and they have a relation like this

```js
Auth.belongsTo(models["users"], {
  foreignKey: "user_id",
  as: "users"
});
```

When trying to get all users with this defaultScope

```js
User.associate = function (models) {
    User.addScope("defaultScope", {
      include: [{
        model: models["auths"],
        as: "auths"
      }]
    });
};
```

The count value is equal to the number of auths that are related to each user returned.

See this [SandBox](https://codesandbox.io/s/moleculer-pagination-not-working-correctly-hm4jo) for a working sample.
 
Fix for #302