### PR TITLE
fix #305 - Async custom validation

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -942,8 +942,9 @@ module.exports = {
 		// Transform entity validation schema to checker function
 		if (this.broker.validator && _.isObject(this.settings.entityValidator) && !_.isFunction(this.settings.entityValidator)) {
 			const check = this.broker.validator.compile(this.settings.entityValidator);
-			this.settings.entityValidator = entity => {
-				const res = check(entity);
+			this.settings.entityValidator = async entity => {
+				let res = check(entity);
+				if (check.async === true || (res.then) instanceof Function) res = await res;
 				if (res === true)
 					return Promise.resolve();
 				else


### PR DESCRIPTION
Fixed async validation errors (issue #305).

If you try without the new update will always be thrown a validation error without any data, because on

```js
let res = check(entity);
if (res === true)
    return Promise.resolve();
```

if you are using an async custom validation ```res``` will be equal to *Promise{<fullfilled/rejected>, true/data}*

For detecting that's an async function it's used the ```async``` property, like said in the docs of [Fastest Validator](https://github.com/icebob/fastest-validator#asynchronous-custom-validations), if using another type of validator check the presence of ```then``` function
```js
if (check.async || (res.then) instanceof Function) res = await res;
```