### PR TITLE
findAndCountAll function added

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -130,6 +130,24 @@ class SequelizeDbAdapter {
 	}
 
 	/**
+	 * Find all entities by filters and count entities by filters.
+	 *
+	 * Available filter props:
+	 * 	- limit
+	 *  - offset
+	 *  - sort
+	 *  - where
+	 *
+	 * @param {any} filters
+	 * @returns {Promise}
+	 *
+	 * @memberof SequelizeDbAdapter
+	 */
+	 findAndCountAll(filters) {
+		return this.model.findAndCountAll(filters);
+	}
+
+	/**
 	 * Find an entity by query
 	 *
 	 * @param {Object} query


### PR DESCRIPTION
I could use count, find functions which are already existed. But I want to call just one function native Sequelize function. So I added this function