### PR TITLE
Feature proposal - BeforeEntity(Change|Update|Remove) lifecycle events

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -439,6 +439,23 @@ module.exports = {
 		},
 
 		/**
+		 * Call before entity lifecycle events
+		 *
+		 * @methods
+		 * @param {String} type
+		 * @param {Object} entity
+		 * @param {Context} ctx
+		 * @returns {Promise}
+		 */
+		beforeEntityChange(type, entity, ctx) {
+			const eventName = `beforeEntity${_.capitalize(type)}`;
+			if (this.schema[eventName] == null) {
+				return Promise.resolve(entity);
+			}
+			return Promise.resolve(this.schema[eventName].call(this, entity, ctx));
+		},
+
+		/**
 		 * Clear the cache & call entity lifecycle events
 		 *
 		 * @methods
@@ -786,10 +803,15 @@ module.exports = {
 		 */
 		_create(ctx, params) {
 			let entity = params;
-			return this.validateEntity(entity)
+			return this.beforeEntityChange("create", entity, ctx)
+				.then((entity)=>this.validateEntity(entity))
 				// Apply idField
-				.then(entity => this.adapter.beforeSaveTransformID(entity, this.settings.idField))
-				.then(entity => this.adapter.insert(entity))
+				.then(entity => 
+					this.adapter.beforeSaveTransformID(entity, this.settings.idField)
+				)
+				.then(entity => 
+					this.adapter.insert(entity)
+				)
 				.then(doc => this.transformDocuments(ctx, {}, doc))
 				.then(json => this.entityChanged("created", json, ctx).then(() => json));
 		},
@@ -808,7 +830,9 @@ module.exports = {
 			return Promise.resolve()
 				.then(() => {
 					if (Array.isArray(params.entities)) {
-						return this.validateEntity(params.entities)
+						return Promise.all(params.entities.map(entity => this.beforeEntityChange("create", entity, ctx)))
+							.then(entities=>this.validateEntity(entities))
+							.then(entities => Promise.all(entities.map(entity => this.beforeEntityChange("create", entity, ctx))))
 							// Apply idField
 							.then(entities => {
 								if (this.settings.idField === "_id")
@@ -818,7 +842,8 @@ module.exports = {
 							.then(entities => this.adapter.insertMany(entities));
 					}
 					else if (params.entity) {
-						return this.validateEntity(params.entity)
+						return this.beforeEntityChange("create", params.entity, ctx)
+							.then(entity=>this.validateEntity(entity))
 							// Apply idField
 							.then(entity => this.adapter.beforeSaveTransformID(entity, this.settings.idField))
 							.then(entity => this.adapter.insert(entity));
@@ -888,19 +913,25 @@ module.exports = {
 		 */
 		_update(ctx, params) {
 			let id;
-			let sets = {};
-			// Convert fields from params to "$set" update object
-			Object.keys(params).forEach(prop => {
-				if (prop == "id" || prop == this.settings.idField)
-					id = this.decodeID(params[prop]);
-				else
-					sets[prop] = params[prop];
-			});
+			
+			return Promise.resolve()
+				.then(()=>this.beforeEntityChange("update", params, ctx))
+				.then((params)=>{
+					let sets = {};
+					// Convert fields from params to "$set" update object
+					Object.keys(params).forEach(prop => {
+						if (prop == "id" || prop == this.settings.idField)
+							id = this.decodeID(params[prop]);
+						else
+							sets[prop] = params[prop];
+					});
 
-			if (this.settings.useDotNotation)
-				sets = flatten(sets, { safe: true });
+					if (this.settings.useDotNotation)
+						sets = flatten(sets, { safe: true });
 
-			return this.adapter.updateById(id, { "$set": sets })
+					return sets;
+				})
+				.then((sets)=>this.adapter.updateById(id, { "$set": sets }))
 				.then(doc => {
 					if (!doc)
 						return Promise.reject(new EntityNotFoundError(id));
@@ -921,7 +952,9 @@ module.exports = {
 		 */
 		_remove(ctx, params) {
 			const id = this.decodeID(params.id);
-			return this.adapter.removeById(id)
+			return Promise.resolve()
+				.then(()=>this.beforeEntityChange("remove", params, ctx))
+				.then(()=>this.adapter.removeById(id))
 				.then(doc => {
 					if (!doc)
 						return Promise.reject(new EntityNotFoundError(params.id));

--- a/packages/moleculer-db/test/unit/index.methods.spec.js
+++ b/packages/moleculer-db/test/unit/index.methods.spec.js
@@ -130,10 +130,11 @@ describe("Test DbService methods", () => {
 		it("should call adapter.insert", () => {
 			adapter.insert.mockClear();
 			service.transformDocuments.mockClear();
+			const p = {};
+			service.beforeEntityChange = jest.fn(() => Promise.resolve(p));
 			service.entityChanged = jest.fn(() => Promise.resolve());
 			service.validateEntity = jest.fn(entity => Promise.resolve(entity));
 
-			const p = {};
 
 			return service._create(Context, p).catch(protectReject).then(res => {
 				expect(res).toEqual(doc);
@@ -147,6 +148,9 @@ describe("Test DbService methods", () => {
 				expect(service.transformDocuments).toHaveBeenCalledTimes(1);
 				expect(service.transformDocuments).toHaveBeenCalledWith(Context, p, doc);
 
+				expect(service.beforeEntityChange).toHaveBeenCalledTimes(1);
+				expect(service.beforeEntityChange).toHaveBeenCalledWith("create", p, Context);
+
 				expect(service.entityChanged).toHaveBeenCalledTimes(1);
 				expect(service.entityChanged).toHaveBeenCalledWith("created", doc, Context);
 			});
@@ -158,12 +162,15 @@ describe("Test DbService methods", () => {
 		it("should call adapter.insert", () => {
 			adapter.insert.mockClear();
 			service.transformDocuments.mockClear();
-			service.entityChanged = jest.fn(() => Promise.resolve());
-			service.validateEntity = jest.fn(entity => Promise.resolve(entity));
 
 			const p = {
 				entity: {}
 			};
+
+			service.beforeEntityChange = jest.fn(() => Promise.resolve(p.entity));
+			service.entityChanged = jest.fn(() => Promise.resolve());
+			service.validateEntity = jest.fn(entity => Promise.resolve(entity));
+
 
 			return service._insert(Context, p).catch(protectReject).then(res => {
 				expect(res).toEqual(doc);
@@ -177,6 +184,9 @@ describe("Test DbService methods", () => {
 				expect(service.transformDocuments).toHaveBeenCalledTimes(1);
 				expect(service.transformDocuments).toHaveBeenCalledWith(Context, {}, doc);
 
+				expect(service.beforeEntityChange).toHaveBeenCalledTimes(1);
+				expect(service.beforeEntityChange).toHaveBeenCalledWith("create", {}, Context);
+
 				expect(service.entityChanged).toHaveBeenCalledTimes(1);
 				expect(service.entityChanged).toHaveBeenCalledWith("created", doc, Context);
 			});
@@ -185,12 +195,13 @@ describe("Test DbService methods", () => {
 		it("should call adapter.insertMany", () => {
 			adapter.insert.mockClear();
 			service.transformDocuments.mockClear();
-			service.entityChanged = jest.fn(() => Promise.resolve());
-			service.validateEntity = jest.fn(entity => Promise.resolve(entity));
-
 			const p = {
 				entities: []
 			};
+			service.beforeEntityChange = jest.fn();
+			service.entityChanged = jest.fn(() => Promise.resolve());
+			service.validateEntity = jest.fn(entity => Promise.resolve(entity));
+
 
 			return service._insert(Context, p).catch(protectReject).then(res => {
 				expect(res).toEqual(docs);
@@ -204,6 +215,8 @@ describe("Test DbService methods", () => {
 				expect(service.transformDocuments).toHaveBeenCalledTimes(1);
 				expect(service.transformDocuments).toHaveBeenCalledWith(Context, {}, docs);
 
+				expect(service.beforeEntityChange).toHaveBeenCalledTimes(0); //since entities array is empty
+
 				expect(service.entityChanged).toHaveBeenCalledTimes(1);
 				expect(service.entityChanged).toHaveBeenCalledWith("created", docs, Context);
 			});
@@ -215,14 +228,15 @@ describe("Test DbService methods", () => {
 		it("should call adapter.updateById", () => {
 			adapter.updateById.mockClear();
 			service.transformDocuments.mockClear();
-			service.entityChanged = jest.fn(() => Promise.resolve());
-			service.decodeID = jest.fn(id => id);
-
 			const p = {
 				_id: 123,
 				name: "John",
 				age: 45
 			};
+			service.beforeEntityChange = jest.fn(() => Promise.resolve(p));
+			service.entityChanged = jest.fn(() => Promise.resolve());
+			service.decodeID = jest.fn(id => id);
+
 
 			return service._update(Context, p).catch(protectReject).then(res => {
 				expect(res).toEqual(doc);
@@ -235,6 +249,9 @@ describe("Test DbService methods", () => {
 
 				expect(service.transformDocuments).toHaveBeenCalledTimes(1);
 				expect(service.transformDocuments).toHaveBeenCalledWith(Context, {}, doc);
+
+				expect(service.beforeEntityChange).toHaveBeenCalledTimes(1);
+				expect(service.beforeEntityChange).toHaveBeenCalledWith("update", p, Context);
 
 				expect(service.entityChanged).toHaveBeenCalledTimes(1);
 				expect(service.entityChanged).toHaveBeenCalledWith("updated", doc, Context);
@@ -255,6 +272,8 @@ describe("Test DbService methods", () => {
 				name: { first: "John", last: "Doe" }
 			};
 
+			service.beforeEntityChange = jest.fn(() => Promise.resolve(p));
+
 			return service._update(Context, p).catch(protectReject).then(res => {
 				expect(res).toEqual(doc);
 
@@ -267,7 +286,7 @@ describe("Test DbService methods", () => {
 					},
 				});
 			});
-		})
+		});
 	});
 
 	describe("Test `_remove` method", () => {
@@ -275,10 +294,11 @@ describe("Test DbService methods", () => {
 		it("should call adapter.remove", () => {
 			adapter.removeById.mockClear();
 			service.transformDocuments.mockClear();
+			const p = { id: 3 };
+			service.beforeEntityChange = jest.fn(() => Promise.resolve(p));
 			service.entityChanged = jest.fn(() => Promise.resolve());
 			service.decodeID = jest.fn(id => id);
 
-			const p = { id: 3 };
 
 			return service._remove(Context, p).catch(protectReject).then(res => {
 				expect(res).toEqual(3);
@@ -291,6 +311,9 @@ describe("Test DbService methods", () => {
 
 				expect(service.transformDocuments).toHaveBeenCalledTimes(1);
 				expect(service.transformDocuments).toHaveBeenCalledWith(Context, {}, 3);
+
+				expect(service.beforeEntityChange).toHaveBeenCalledTimes(1);
+				expect(service.beforeEntityChange).toHaveBeenCalledWith("remove", p, Context);
 
 				expect(service.entityChanged).toHaveBeenCalledTimes(1);
 				expect(service.entityChanged).toHaveBeenCalledWith("removed", 3, Context);

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -332,6 +332,9 @@ describe("Test entityChanged method", () => {
 	const service = broker.createService(DbService, {
 		name: "store",
 		settings: {},
+		beforeEntityCreate: jest.fn(() => Promise.resolve()),
+		beforeEntityUpdate: jest.fn(() => Promise.resolve()),
+		beforeEntityRemove: jest.fn(() => Promise.resolve()),
 		entityCreated: jest.fn(),
 		entityUpdated: jest.fn(),
 		entityRemoved: jest.fn(),
@@ -341,6 +344,27 @@ describe("Test entityChanged method", () => {
 
 	let ctx = {};
 	let doc = { id: 5 };
+
+	it("should call `beforeEntityCreate` event", () => {
+		return service.beforeEntityChange("create", {}, ctx).catch(protectReject).then(() => {
+			expect(service.schema.beforeEntityCreate).toHaveBeenCalledTimes(1);
+			expect(service.schema.beforeEntityCreate).toHaveBeenCalledWith({}, ctx);
+		});
+	});
+
+	it("should call `beforeEntityUpdate` event", () => {
+		return service.beforeEntityChange("update",  {}, ctx).catch(protectReject).then(() => {
+			expect(service.schema.beforeEntityUpdate).toHaveBeenCalledTimes(1);
+			expect(service.schema.beforeEntityUpdate).toHaveBeenCalledWith({}, ctx);
+		});
+	});
+
+	it("should call `beforeEntityRemove` event", () => {
+		return service.beforeEntityChange("remove",{}, ctx).catch(protectReject).then(() => {
+			expect(service.schema.beforeEntityRemove).toHaveBeenCalledTimes(1);
+			expect(service.schema.beforeEntityRemove).toHaveBeenCalledWith({}, ctx);
+		});
+	});
 
 	it("should call `entityCreated` event", () => {
 		return service.entityChanged("created", doc, ctx).catch(protectReject).then(() => {
@@ -1015,7 +1039,7 @@ describe("Test validateEntity method", () => {
 				expect(err.data[0].type).toBe("required");
 				expect(err.data[0].field).toBe("id");
 			});
-		})
+		});
 
 	});
 


### PR DESCRIPTION
## :memo: Description

Runs a lifecycle event before an entity is created, updated or removed. Right now, we only have entityCreated, entityUpdated and entityRemoved, which run AFTER the entity change.

## :factory: Use case example

Having a lifecycle event before allows for a better handling of createdAt and updatedAt data fields. In the [docs](https://moleculer.services/docs/0.14/moleculer-db.html#Data-Manipulation), it is said hooks can be used for that purpose, however, hooks are only run before actions, not methods. Using this._create, this._insert, this._update or this._remove would bypass the hook, leaving the createdAt and updatedAt fields empty.

### :dart: Relevant issues
No issue that I know of

### :gem: Type of change

- [x] New feature (non-breaking change which adds functionality)

## :vertical_traffic_light: How Has This Been Tested?

- [x] Added simple unit tests
- [x] Using the patch via patch-package in my own code and it works.

## :checkered_flag: Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [x] I have commented my code, particularly in hard-to-understand areas
