### PR TITLE
feat: Recursive deep populate

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -603,10 +603,17 @@ module.exports = {
 
 			const groupedPopulateFields = _.groupBy(
 				populateFields,
-				(populateField)=>Object.keys(this.settings.populates).find(
-					(populatesField)=>populateField === populatesField || populateField.startsWith(populatesField + ".")
-				)
+				(populateField)=> {
+					let key = Object.keys(this.settings.populates).find(
+						(populatesField)=>populateField === populatesField || populateField.startsWith(populatesField + ".")
+					);
+
+					if (key) return key;
+					return "_invalid";
+				}
 			);
+
+			delete groupedPopulateFields["_invalid"];
 	
 			let promises = [];
 			_.forIn(this.settings.populates, (rule, populatesField) => {

--- a/packages/moleculer-db/test/integration/populates.spec.js
+++ b/packages/moleculer-db/test/integration/populates.spec.js
@@ -159,11 +159,24 @@ describe("Test populates feature", () => {
 		});
 	});
 
-	it("should deeply populate groups", () => {
-		return broker.call("posts.get", { id: posts[0]._id, populate: ["author.group","reviewer.group"] }).catch(protectReject).then(res => {
+	it("should deeply populate all groups", () => {
+		return broker.call("posts.get", { id: posts[0]._id, populate: ["author.group","reviewer.group", "title.invalid"] }).catch(protectReject).then(res => {
 			expect(res).toEqual({
 				"_id": posts[0]._id,
 				"author": {"_id": users[2]._id, "name": "Walter", "username": "walter", group:{"_id": groups[2]._id, "name": "groupC"}},
+				"reviewerId":users[0]._id,
+				"reviewer": {"_id": users[0]._id, "name": users[0].name, "username":users[0].username, group:{"_id": groups[0]._id, "name": "groupA"}},
+				"content": "This is the content",
+				"title": "My first post"
+			});
+		});
+	});
+
+	it("should deeply populate one group", () => {
+		return broker.call("posts.get", { id: posts[0]._id, populate: ["author.invalid","reviewer.group", "title.invalid"] }).catch(protectReject).then(res => {
+			expect(res).toEqual({
+				"_id": posts[0]._id,
+				"author": {"_id": users[2]._id, "name": "Walter", "username": "walter", group:groups[2]._id},
 				"reviewerId":users[0]._id,
 				"reviewer": {"_id": users[0]._id, "name": users[0].name, "username":users[0].username, group:{"_id": groups[0]._id, "name": "groupA"}},
 				"content": "This is the content",

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -1015,7 +1015,7 @@ describe("Test validateEntity method", () => {
 				expect(err.data[0].type).toBe("required");
 				expect(err.data[0].field).toBe("id");
 			});
-		})
+		});
 
 	});
 


### PR DESCRIPTION
📝 Description

This allows to recursively populate fields. Example:

if
```
postsService.settings.populates = {
	author: "users.get",
        reviewer: "users.get",
        "liked.by": "users.get"
};

usersService.settings.populates = {
	group: "groups.get"
};
```

Then it is now possible to populate groups from a posts query like this:

```
const post = await posts.get({
    id: postId,
   populate: ["author.group", "reviewer.group", "liked.by.group"]
})

post.author.group.name //populated;
post.reviewer.group.name //populated;
post.liked.by.group.name //populated;
```



🎯 Relevant issues
No issue that I know of

💎 Type of change
 New feature (non-breaking change which adds functionality)

🚦 How Has This Been Tested?
- [x] Added integration tests
- [x] Using the patch via patch-package in my own code and it works.

🏁 Checklist:
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I have commented my code, particularly in hard-to-understand areas