### PR TITLE
fix authorize fields unsafe check

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -566,41 +566,41 @@ module.exports = {
 		/**
 		 * Authorize the required field list. Remove fields which is not exist in the `this.settings.fields`
 		 *
-		 * @param {Array} fields
+		 * @param {Array} askedFields
 		 * @returns {Array}
 		 */
-		authorizeFields(fields) {
+		authorizeFields(askedFields) {
 			if (this.settings.fields && this.settings.fields.length > 0) {
-				let res = [];
-				if (Array.isArray(fields) && fields.length > 0) {
-					fields.forEach(f => {
-						if (this.settings.fields.indexOf(f) !== -1) {
-							res.push(f);
+				let allowedFields = [];
+				if (Array.isArray(askedFields) && askedFields.length > 0) {
+					askedFields.forEach(askedField => {
+						if (this.settings.fields.indexOf(askedField) !== -1) {
+							allowedFields.push(askedField);
 							return;
 						}
 
-						if (f.indexOf(".") !== -1) {
-							let parts = f.split(".");
+						if (askedField.indexOf(".") !== -1) {
+							let parts = askedField.split(".");
 							while (parts.length > 1) {
 								parts.pop();
 								if (this.settings.fields.indexOf(parts.join(".")) !== -1) {
-									res.push(f);
+									allowedFields.push(askedField);
 									break;
 								}
 							}
 						}
 
-						let nestedFields = this.settings.fields.filter(prop => prop.indexOf(f + ".") !== -1);
+						let nestedFields = this.settings.fields.filter(settingField => settingField.indexOf(askedField + ".") !== -1);
 						if (nestedFields.length > 0) {
-							res = res.concat(nestedFields);
+							allowedFields = allowedFields.concat(nestedFields);
 						}
 					});
 					//return _.intersection(f, this.settings.fields);
 				}
-				return res;
+				return allowedFields;
 			}
 
-			return fields;
+			return askedFields;
 		},
 
 		/**
@@ -832,10 +832,10 @@ module.exports = {
 			return this.beforeEntityChange("create", entity, ctx)
 				.then((entity)=>this.validateEntity(entity))
 				// Apply idField
-				.then(entity => 
+				.then(entity =>
 					this.adapter.beforeSaveTransformID(entity, this.settings.idField)
 				)
-				.then(entity => 
+				.then(entity =>
 					this.adapter.insert(entity)
 				)
 				.then(doc => this.transformDocuments(ctx, {}, doc))
@@ -939,7 +939,7 @@ module.exports = {
 		 */
 		_update(ctx, params) {
 			let id;
-			
+
 			return Promise.resolve()
 				.then(()=>this.beforeEntityChange("update", params, ctx))
 				.then((params)=>{

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -585,7 +585,7 @@ module.exports = {
 								parts.pop();
 								if (this.settings.fields.indexOf(parts.join(".")) !== -1) {
 									allowedFields.push(askedField);
-									break;
+									return;
 								}
 							}
 						}

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -590,7 +590,7 @@ module.exports = {
 							}
 						}
 
-						let nestedFields = this.settings.fields.filter(settingField => settingField.indexOf(askedField + ".") !== -1);
+						let nestedFields = this.settings.fields.filter(settingField => settingField.startsWith(askedField + "."));
 						if (nestedFields.length > 0) {
 							allowedFields = allowedFields.concat(nestedFields);
 						}

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -655,7 +655,7 @@ describe("Test authorizeFields method", () => {
 			expect(res).toEqual(["id", "name", "bio.body.height", "bio.body.hair.color"]);
 		});
 
-		it("should remove empty", () => {
+		it("should return empty", () => {
 			const res = service.authorizeFields(["carrier"]);
 			expect(res).toEqual([]);
 		});

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -636,7 +636,7 @@ describe("Test authorizeFields method", () => {
 			name: "store",
 			adapter: mockAdapter,
 			settings: {
-				fields: ["id", "name", "address", "bio.body"]
+				fields: ["id", "name", "address", "bio.body", "mobile.carrier.name"]
 			}
 		});
 
@@ -653,6 +653,11 @@ describe("Test authorizeFields method", () => {
 		it("should remove the disabled bio fields", () => {
 			const res = service.authorizeFields(["id", "name", "bio.body.height", "bio.male", "bio.dob.year", "bio.body.hair.color"]);
 			expect(res).toEqual(["id", "name", "bio.body.height", "bio.body.hair.color"]);
+		});
+
+		it("should remove empty", () => {
+			const res = service.authorizeFields(["carrier"]);
+			expect(res).toEqual([]);
 		});
 	});
 


### PR DESCRIPTION
https://github.com/moleculerjs/moleculer-db/blob/f26871e4429190b4199805065b005c41112bcb5c/packages/moleculer-db/src/index.js#L593
if `settings.fields = [...,"author.user.name"]`, and client asked for `fields = "user"` will return unwanted `author` field