### PR TITLE
feat: allow filter object fields inside an array

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -13,6 +13,7 @@ const { MoleculerClientError, ValidationError } = require("moleculer").Errors;
 const { EntityNotFoundError } = require("./errors");
 const MemoryAdapter = require("./memory-adapter");
 const pkg = require("../package.json");
+const { deepGet } = require("./utils");
 
 /**
  * Service mixin to access database entities
@@ -553,9 +554,8 @@ module.exports = {
 			if (Array.isArray(fields)) {
 				let res = {};
 				fields.forEach(n => {
-					const v = _.get(doc, n);
-					if (v !== undefined)
-						_.set(res, n, v);
+					const paths = n.split(".$.");
+					deepGet(doc, paths, res);
 				});
 				return res;
 			}

--- a/packages/moleculer-db/src/utils.js
+++ b/packages/moleculer-db/src/utils.js
@@ -2,19 +2,25 @@ const _ = require("lodash");
 
 function deepGet(doc, fieldPaths, res, i = 0) {
 	while (i < fieldPaths.length) {
-		const path = fieldPaths[i++];
+		const path = fieldPaths[i++]; // increase i
 		doc = _.get(doc, path);
 		if (doc !== undefined) {
-			if ((Array.isArray(doc) && fieldPaths.length > i)) {
-				const resVal = _.get(res, path, []);
-				_.set(res, path, doc.map((item, index) => {
-					const obj = resVal[index] || {};
-					deepGet(item, [].concat(fieldPaths), obj, i);
-					return obj;
-				}));
+			if (fieldPaths.length > i) { // still remain paths
+				if (Array.isArray(doc)) {
+					const resVal = _.get(res, path, []);
+					_.set(res, path, doc.map((item, index) => {
+						const obj = resVal[index] || {};
+						deepGet(item, [].concat(fieldPaths), obj, i);
+						return obj;
+					}));
+				} else {
+					return; // if .$. dont apply to array, return
+				}
 			} else {
 				_.set(res, path, doc);
 			}
+		} else {
+			return;
 		}
 	}
 }

--- a/packages/moleculer-db/src/utils.js
+++ b/packages/moleculer-db/src/utils.js
@@ -10,7 +10,7 @@ function deepGet(doc, fieldPaths, res, i = 0) {
 					const resVal = _.get(res, path, []);
 					_.set(res, path, doc.map((item, index) => {
 						const obj = resVal[index] || {};
-						deepGet(item, [].concat(fieldPaths), obj, i);
+						deepGet(item, fieldPaths, obj, i);
 						return obj;
 					}));
 				} else {

--- a/packages/moleculer-db/src/utils.js
+++ b/packages/moleculer-db/src/utils.js
@@ -1,0 +1,21 @@
+const _ = require("lodash");
+
+function deepGet(doc, fieldPaths, res, i = 0) {
+	while (i < fieldPaths.length) {
+		const path = fieldPaths[i++];
+		doc = _.get(doc, path);
+		if (doc !== undefined) {
+			if ((Array.isArray(doc) && fieldPaths.length > i)) {
+				const resVal = _.get(res, path, []);
+				_.set(res, path, doc.map((item, index) => {
+					const obj = resVal[index] || {};
+					deepGet(item, [].concat(fieldPaths), obj, i);
+					return obj;
+				}));
+			} else {
+				_.set(res, path, doc);
+			}
+		}
+	}
+}
+exports.deepGet = deepGet;

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -727,6 +727,64 @@ describe("Test filterFields method", () => {
 		});
 	});
 
+	it("should filter with nested fields in array", () => {
+		const res = service.filterFields({
+			id : 1,
+			name: "Walter",
+			address: {
+				city: "Albuquerque",
+				state: "NM",
+				zip: 87111
+			},
+			cars: [
+				{id: 1, name: "BMW", model: "320i", wheels: [
+					{ placement: "front-left", id: 1},
+					{ placement: "front-right", id: 2},
+					{ placement: "behind-left", id: 3},
+					{ placement: "behind-right", id: 4},
+				]},
+				{id: 2, name: "BMW", model: "520i", wheels: [
+					{ placement: "front-left", id: 1},
+					{ placement: "front-right", id: 2},
+					{ placement: "behind-left", id: 3},
+					{ placement: "behind-right", id: 4},
+				]},
+				{id: 3, name: "AUDI", model: "Q7", wheels: [
+					{ placement: "front-left", id: 1, histories: []},
+					{ placement: "front-right", id: 2, histories: [
+						{date: "11/11/2011", message: "replace new 2011"}
+					]},
+					{ placement: "behind-left", id: 3, histories: []},
+					{ placement: "behind-right", id: 4, histories: [
+						{date: "12/12/2012", message: "replace new 2012"}
+					]},
+				]},
+			]
+		}, ["name", "cars.$.id", "cars.$.name", "cars.$.wheels.$.placement", "cars.$.wheels.$.histories.$.date", "cars.$.wheels.$.histories.$.non-existed"]);
+		expect(res).toEqual({
+			name: "Walter",
+			cars: [
+				{id: 1, name: "BMW", wheels: [
+					{ placement: "front-left" },
+					{ placement: "front-right" },
+					{ placement: "behind-left" },
+					{ placement: "behind-right" },
+				]},
+				{id: 2, name: "BMW", wheels: [
+					{ placement: "front-left" },
+					{ placement: "front-right" },
+					{ placement: "behind-left" },
+					{ placement: "behind-right" },
+				]},
+				{id: 3, name: "AUDI", wheels: [
+					{ placement: "front-left", histories: [] },
+					{ placement: "front-right", histories: [{date: "11/11/2011"}] },
+					{ placement: "behind-left", histories: [] },
+					{ placement: "behind-right", histories: [{date: "12/12/2012"}] },
+				]},
+			]
+		});
+	});
 });
 
 describe("Test populateDocs method", () => {

--- a/packages/moleculer-db/test/unit/utils.spec.js
+++ b/packages/moleculer-db/test/unit/utils.spec.js
@@ -1,0 +1,94 @@
+const { deepGet } = require("../../src/utils");
+describe("test utils.js", function () {
+	describe("test function deepGet", () => {
+		const doc = {
+			id : 1,
+			name: "Walter",
+			address: {
+				city: "Albuquerque",
+				state: "NM",
+				zip: 87111
+			},
+			cars: [
+				{id: 1, name: "BMW", model: "320i", wheels: [
+					{ placement: "front-left", id: 1},
+					{ placement: "front-right", id: 2},
+					{ placement: "behind-left", id: 3},
+					{ placement: "behind-right", id: 4},
+				]},
+				{id: 2, name: "BMW", model: "520i", wheels: [
+					{ placement: "front-left", id: 1},
+					{ placement: "front-right", id: 2},
+					{ placement: "behind-left", id: 3},
+					{ placement: "behind-right", id: 4},
+				]},
+				{id: 3, name: "AUDI", model: "Q7", wheels: [
+					{ placement: "front-left", id: 1},
+					{ placement: "front-right", id: 2},
+					{ placement: "behind-left", id: 3},
+					{ placement: "behind-right", id: 4},
+				]},
+			]
+		};
+
+		it("get name", () => {
+			const fieldPaths = ["name"];
+			const res = {};
+			deepGet(doc, fieldPaths, res);
+			expect(res).toEqual({"name": "Walter"});
+		});
+
+		it("get address.city", () => {
+			const fieldPaths = ["address.city"];
+			const res = {};
+			deepGet(doc, fieldPaths, res);
+			expect(res).toEqual({"address": {city: "Albuquerque"}});
+		});
+
+		it("get cars", () => {
+			const fieldPaths = ["cars"];
+			const res = {};
+			deepGet(doc, fieldPaths, res);
+			expect(res).toEqual({ cars: doc.cars });
+		});
+
+		it("get cars.$.name", () => {
+			const fieldPaths = ["cars", "name"];
+			const res = {};
+			deepGet(doc, fieldPaths, res);
+			expect(res).toEqual({
+				cars: [
+					{ name: "BMW" },
+					{ name: "BMW" },
+					{ name: "AUDI" },
+				]});
+		});
+
+		it("get cars.$.name", () => {
+			const fieldPaths = ["cars", "wheels", "placement"];
+			const res = {};
+			deepGet(doc, fieldPaths, res);
+			expect(res).toEqual({
+				cars: [
+					{wheels: [
+						{ placement: "front-left" },
+						{ placement: "front-right" },
+						{ placement: "behind-left" },
+						{ placement: "behind-right" },
+					]},
+					{wheels: [
+						{ placement: "front-left" },
+						{ placement: "front-right" },
+						{ placement: "behind-left" },
+						{ placement: "behind-right" },
+					]},
+					{wheels: [
+						{ placement: "front-left" },
+						{ placement: "front-right" },
+						{ placement: "behind-left" },
+						{ placement: "behind-right" },
+					]},
+				]});
+		});
+	});
+});


### PR DESCRIPTION
use `.$.` to deeply filter fields in array elements
please look at test

`cars.$.wheels.$.histories.$.date` is used to get `date` property of `histories`, which is an array property of `wheels` - which, again, is an array property of `cars`