### PR TITLE
use this.model.db as NativeConnection instance 0x0a0d Today 7:13 PM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,12 @@ jobs:
           ${{ runner.os }}-
 
     - name: Install dependencies
-      run: npm run setup-no-old-node
-      if: ${{ matrix.node-version == '10.x' || matrix.node-version == '12.x' }}
+      run: npm install && lerna bootstrap --ignore moleculer-db-adapter-prisma --ignore moleculer-db-adapter-mongoose
+      if: ${{ matrix.node-version == '10.x' }}
+
+    - name: Install dependencies
+      run: npm install && lerna bootstrap --ignore moleculer-db-adapter-prisma
+      if: ${{ matrix.node-version == '12.x' }}
 
     - name: Install dependencies
       run: npm run setup

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "scripts": {
     "setup": "npm install && lerna bootstrap",
-    "setup-no-old-node": "npm install && lerna bootstrap --ignore moleculer-db-adapter-prisma --ignore moleculer-db-adapter-mongoose",
     "clean": "lerna clean",
     "dev": "nodemon dev.js",
     "demo": "node dev.js",

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -1,5 +1,5 @@
 "use strict";
-if (process.versions.node.split(".")[0] < 14) {
+if (process.versions.node.split(".")[0] < 12) {
 	console.log("Skipping Mongoose tests because node version is too low");
 	it("Skipping Mongoose tests because node version is too low", () => {});
 } else {

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -139,13 +139,12 @@ if (process.versions.node.split(".")[0] < 14) {
 			beforeEach(() => {
 				mongoose.connection.readyState =
 					mongoose.connection.states.disconnected;
-				mongoose.connect = jest.fn(() => {
-					mongoose.connection.readyState =
-						mongoose.connection.states.connected;
-					return Promise.resolve({
-						connection: { ...fakeDb, db: fakeDb },
-						model: jest.fn(() => fakeModel),
-					});
+				mongoose.createConnection = jest.fn(() => {
+					return {
+						...fakeDb,
+						db: fakeDb,
+						readyState: mongoose.connection.states.connected,
+					};
 				});
 			});
 
@@ -153,14 +152,14 @@ if (process.versions.node.split(".")[0] < 14) {
 				fakeDb.on.mockClear();
 
 				adapter.opts = undefined;
-				adapter.model = jest.fn(() => fakeModel);
+				adapter.model = fakeModel;
 
 				return adapter
 					.connect()
 					.catch(protectReject)
 					.then(() => {
-						expect(mongoose.connect).toHaveBeenCalledTimes(1);
-						expect(mongoose.connect).toHaveBeenCalledWith(
+						expect(mongoose.createConnection).toHaveBeenCalledTimes(1);
+						expect(mongoose.createConnection).toHaveBeenCalledWith(
 							"mongodb://localhost",
 							undefined
 						);
@@ -190,8 +189,8 @@ if (process.versions.node.split(".")[0] < 14) {
 					.connect()
 					.catch(protectReject)
 					.then(() => {
-						expect(mongoose.connect).toHaveBeenCalledTimes(1);
-						expect(mongoose.connect).toHaveBeenCalledWith(
+						expect(mongoose.createConnection).toHaveBeenCalledTimes(1);
+						expect(mongoose.createConnection).toHaveBeenCalledWith(
 							adapter.uri,
 							adapter.opts
 						);
@@ -250,8 +249,9 @@ if (process.versions.node.split(".")[0] < 14) {
 					mongoose.connection.readyState =
 						mongoose.connection.states.connected;
 					return {
-						connection: { db: fakeDb, ...fakeDb },
-						model: jest.fn(() => fakeModel),
+						db: fakeDb,
+						...fakeDb,
+						readyState: mongoose.connection.states.connected
 					};
 				});
 


### PR DESCRIPTION
this pull includes some improve
- allow to use `this.model.db` if existed
- improve `disconnect` method, please see code comment
- remove limit node version not less than 14 in tests, I dont understand why must do that? I was test with node 12