### PR TITLE
Fix constructor signature of MongoDB adapter in TypeScript

### DIFF
--- a/packages/moleculer-db-adapter-mongo/index.d.ts
+++ b/packages/moleculer-db-adapter-mongo/index.d.ts
@@ -5,7 +5,7 @@ declare module "moleculer-db-adapter-mongo" {
 	import { Collection } from "mongodb";
 	export default class MongoDbAdapter implements DbAdapter {
 		collection: Collection;
-		constructor(opts: object | string);
+		constructor(uri: string, opts?: object | string, dbName?: string);
 
 		/**
 		 * Initialize adapter

--- a/packages/moleculer-db-adapter-mongo/package.json
+++ b/packages/moleculer-db-adapter-mongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moleculer-db-adapter-mongo",
-  "version": "0.4.17",
+  "version": "0.4.16",
   "description": "MongoDB native adapter for Moleculer DB service.",
   "main": "index.js",
   "scripts": {

--- a/packages/moleculer-db-adapter-mongo/package.json
+++ b/packages/moleculer-db-adapter-mongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moleculer-db-adapter-mongo",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "MongoDB native adapter for Moleculer DB service.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We ran into an issue in our TypeScript code when we tried to use moleculer-db-adapter-mongo 0.4.16, because the TypeScript signature did not match the JavaScript code.