### PR TITLE
fix(excludeFields): prevent client from bypassing settings.excludeFields

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -562,11 +562,12 @@ module.exports = {
 
 				// Filter excludeFields
 				.then(json => {
-					const excludeFields = (ctx && params.excludeFields)
+					const askedExcludeFields = (ctx && params.excludeFields)
 						? _.isString(params.excludeFields)
 							? params.excludeFields.split(/\s+/)
 							: params.excludeFields
-						: this.settings.excludeFields;
+						: [];
+					const excludeFields = askedExcludeFields.concat(this.settings.excludeFields || []);
 
 					if (Array.isArray(excludeFields) && excludeFields.length > 0) {
 						return json.map(doc => {


### PR DESCRIPTION
I forgot to merge `settings.excludeFields` with client `params.excludeFields`