### PR TITLE
Update Mongoose Adapter Readme

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/README.md
+++ b/packages/moleculer-db-adapter-mongoose/README.md
@@ -9,7 +9,7 @@ Mongoose adapter for Moleculer DB service
 ## Install
 
 ```bash
-$ npm install moleculer-db moleculer-db-adapter-mongoose mongoose@5.8.11 --save
+$ npm install moleculer-db moleculer-db-adapter-mongoose mongoose@6.5.4 --save
 ```
 
 ## Usage


### PR DESCRIPTION
- updates the version of `mongoose` displayed in the README install instructions for using `moleculer-db` and `moleculer-db-adapter-mongoose` to the correct version supported in version 9+