### PR TITLE
fix(moleculer-db-adapter-mongoose): remove connecting error/warning, Fix #361

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,8 +11,8 @@
 			"program": "${workspaceRoot}/dev",
 			"cwd": "${workspaceRoot}",
 			"args": [
-				"moleculer-db-adapter-mongo",
-				"issue"
+				"moleculer-db-adapter-mongoose",
+				"simple"
 			]
 		},
 		{

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -76,7 +76,6 @@ class MongooseDbAdapter {
 			} else {
 				conn = mongoose.connect(this.uri, this.opts);
 			}
-
 		} else if (this.schema) {
 			conn = new Promise(resolve =>{
 				const 	c = mongoose.createConnection(this.uri, this.opts);
@@ -85,7 +84,6 @@ class MongooseDbAdapter {
 			});
 		}
 
-		// console.log(conn);
 		return conn.then(() => {
 			this.conn = mongoose.connection;
 
@@ -97,8 +95,9 @@ class MongooseDbAdapter {
 				);
 			}
 
-			if(this.model)
+			if(this.model) {
 				this.model = mongoose.model(this.model["modelName"],this.model["schema"]);
+			}
 
 			this.db = mongoose.connection.db;
 

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -247,7 +247,9 @@ class MongooseDbAdapter {
 	 * @memberof MongooseDbAdapter
 	 */
 	updateMany(query, update) {
-		return this.model.updateMany(query, update, { multi: true, "new": true }).then(res => res.n);
+		return this.model.updateMany(query, update, { multi: true, "new": true }).then(res => {
+			return res.modifiedCount;
+		});
 	}
 
 	/**
@@ -272,7 +274,9 @@ class MongooseDbAdapter {
 	 * @memberof MongooseDbAdapter
 	 */
 	removeMany(query) {
-		return this.model.deleteMany(query).then(res => res.n);
+		return this.model.deleteMany(query).then(res => {
+			return res.deletedCount;
+		});
 	}
 
 	/**
@@ -295,7 +299,7 @@ class MongooseDbAdapter {
 	 * @memberof MongooseDbAdapter
 	 */
 	clear() {
-		return this.model.deleteMany({}).then(res => res.n);
+		return this.model.deleteMany({}).then(res => res.deletedCount);
 	}
 
 	/**

--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -72,7 +72,7 @@ class MongooseDbAdapter {
 				this.db = mongoose.connection;
 				return Promise.resolve();
 			} else if (mongoose.connection.readyState == 2) {
-				conn = mongoose.connection.$initialConnection;
+				conn = mongoose.connection.asPromise();
 			} else {
 				conn = mongoose.connect(this.uri, this.opts);
 			}

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -142,11 +142,15 @@ if (process.versions.node.split(".")[0] < 14) {
 				mongoose.connect = jest.fn(() => {
 					mongoose.connection.readyState =
 						mongoose.connection.states.connected;
-					return Promise.resolve({
-						connection: { ...fakeDb, db: fakeDb },
-						model: jest.fn(() => fakeModel),
-					});
+					return Promise.resolve();
 				});
+
+				mongoose.model = jest.fn(() => fakeModel);
+
+				Object.entries(fakeDb).forEach(([k, v]) => {
+					mongoose.connection[k] = v;
+				});
+				mongoose.connection.db = fakeDb;
 			});
 
 			it("call connect with uri", () => {

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -47,9 +47,9 @@ if (process.versions.node.split(".")[0] < 14) {
 			findOne: jest.fn(() => query()),
 			findById: jest.fn(() => query()),
 			create: jest.fn(() => Promise.resolve()),
-			updateMany: jest.fn(() => Promise.resolve({ n: 2 })),
+			updateMany: jest.fn(() => Promise.resolve({ modifiedCount: 2 })),
 			findByIdAndUpdate: jest.fn(() => Promise.resolve(doc)),
-			deleteMany: jest.fn(() => Promise.resolve({ n: 2 })),
+			deleteMany: jest.fn(() => Promise.resolve({ deletedCount: 2 })),
 			findByIdAndRemove: jest.fn(() => Promise.resolve()),
 		}
 	);


### PR DESCRIPTION
This PR is here to fix #361 . 

It seems that, after calling on time `mongoose.connect` . The "connection" promise is available in "mongoose.connection.$initialConnection"

So, the promise will wait one, or the other . 

and I reuse the commons objects from mongoose to setup current connection, events handler, and other . 

tested with mongoose@^6 and mongoose@^7