### PR TITLE
Create an adapter method to handle virtual population

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/README.md
+++ b/packages/moleculer-db-adapter-mongoose/README.md
@@ -60,7 +60,7 @@ new MongooseAdapter("mongodb://127.0.0.1/moleculer-db")
 ```js
 new MongooseAdapter("mongodb://db-server-hostname/my-db", {
     user: process.env.MONGO_USERNAME,
-    pass: process.env.MONGO_PASSWORD
+    pass: process.env.MONGO_PASSWORD,
     keepAlive: true
 })
 ```

--- a/packages/moleculer-db-adapter-mongoose/test/integration/virtuals.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/integration/virtuals.spec.js
@@ -39,6 +39,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					populates: {
 						posts: "posts.get",
 						lastPost: "posts.get",
+						lastPostWithVotes: "posts.get",
 					},
 				},
 			});
@@ -72,18 +73,19 @@ if (process.versions.node.split(".")[0] < 14) {
 				title: "post_2",
 				content: "content 2",
 				author: _user._id,
+				votes: 2,
 			});
 
 			const user = await broker.call("users.get", {
 				id: _user.id,
-				populate: ["posts", "lastPost", "postCount"],
+				populate: ["posts", "postCount", "lastPost", "lastPostWithVotes"],
 			});
 
 			expect(user).toHaveProperty("firstName", "John");
 			expect(user).toHaveProperty("lastName", "Doe");
 			// virtual function without populate
 			expect(user).toHaveProperty("fullName", "John Doe");
-			// virtual populate with ref and count option
+			// virtual populate with refPath and count option
 			expect(user).toHaveProperty("postCount", 2);
 			// virtual populate with ref
 			expect(user).toHaveProperty("posts");
@@ -92,6 +94,9 @@ if (process.versions.node.split(".")[0] < 14) {
 			// virtual populate with justOne option set to "true"
 			expect(user).toHaveProperty("lastPost");
 			expect(user.lastPost).toHaveProperty("_id", _post2.id);
+			// virtual populate with match clause
+			expect(user).toHaveProperty("lastPostWithVotes");
+			expect(user.lastPostWithVotes).toHaveProperty("_id", _post2.id);
 		});
 	});
 }

--- a/packages/moleculer-db-adapter-mongoose/test/models/users.js
+++ b/packages/moleculer-db-adapter-mongoose/test/models/users.js
@@ -14,6 +14,10 @@ const UserSchema = new Schema(
 			required: true,
 			trim: true,
 		},
+		postRef: {
+			type: String,
+			default: "Post"
+		}
 	},
 	{
 		timestamps: true,
@@ -35,7 +39,7 @@ const UserSchema = new Schema(
 			},
 			postCount: {
 				options: {
-					ref: "Post",
+					refPath: "postRef",
 					localField: "_id",
 					foreignField: "author",
 					count: true,
@@ -53,6 +57,15 @@ const UserSchema = new Schema(
 		},
 	}
 );
+
+UserSchema.virtual("lastPostWithVotes", {
+	ref: "Post",
+	localField: "_id",
+	foreignField: "author",
+	justOne: true,
+	match: { votes: { $gt: 0 } },
+	options: { sort: "-createdAt" },
+});
 
 module.exports = {
 	Model: model("User", UserSchema),

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -907,5 +907,35 @@ if (process.versions.node.split(".")[0] < 14) {
 				});
 			});
 		});
+
+		describe("mapVirtualsToLocalFields", () => {
+			it("should map virtual field to localField", () => {
+				const adapter = new MongooseStoreAdapter();
+				const service = broker.createService({
+					name: "store",
+					model: {
+						schema: {
+							virtuals: {
+								idVirtual: {options: {localField: "_id"}},
+								fooVirtual: {options: {localField: "foo"}},
+								barVirtual: {},
+							}
+						}
+					},
+				});
+				adapter.init(broker, service);
+				const ctx = { service, params: {}};
+				const json = {_id: "xxx", foo: "yyy", bar: "zzz"};
+				const res = adapter.mapVirtualsToLocalFields(ctx, json);
+
+				expect(json).toEqual({
+					_id: "xxx",
+					foo: "yyy",
+					bar: "zzz",
+					idVirtual: "xxx",
+					fooVirtual: "yyy"
+				});
+			});
+		});
 	});
 }

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -734,22 +734,8 @@ if (process.versions.node.split(".")[0] < 14) {
 			expect(res._id).toEqual(entry._id);
 		});
 
-		describe("getVirtualPopulateQuery", () => {
+		describe("getNativeVirtualPopulateQuery", () => {
 			describe("stop conditions", () => {
-				it("should return [] when settings.virtuals is false", () => {
-					const adapter = new MongooseStoreAdapter();
-					const service = broker.createService({
-						name: "store",
-						settings: { virtuals: false},
-						model: { schema: { virtuals: { aVirtual: {}}}},
-					});
-					adapter.init(broker, service);
-					const ctx = { service };
-					const res = adapter.getVirtualPopulateQuery(ctx);
-
-					expect(res).toEqual([]);
-				});
-
 				it("should return [] when params.populate is undefined", () => {
 					const adapter = new MongooseStoreAdapter();
 					const service = broker.createService({
@@ -758,7 +744,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					});
 					adapter.init(broker, service);
 					const ctx = { service, params: {}};
-					const res = adapter.getVirtualPopulateQuery(ctx);
+					const res = adapter.getNativeVirtualPopulateQuery(ctx);
 
 					expect(res).toEqual([]);
 				});
@@ -771,7 +757,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					});
 					adapter.init(broker, service);
 					const ctx = { service, params: { populate: []}};
-					const res = adapter.getVirtualPopulateQuery(ctx);
+					const res = adapter.getNativeVirtualPopulateQuery(ctx);
 
 					expect(res).toEqual([]);
 				});
@@ -784,7 +770,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					});
 					adapter.init(broker, service);
 					const ctx = { service, params: { populate: []}};
-					const res = adapter.getVirtualPopulateQuery(ctx);
+					const res = adapter.getNativeVirtualPopulateQuery(ctx);
 
 					expect(res).toEqual([]);
 				});
@@ -797,7 +783,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					});
 					adapter.init(broker, service);
 					const ctx = { service, params: { populate: ["notaVirtual"]}};
-					const res = adapter.getVirtualPopulateQuery(ctx);
+					const res = adapter.getNativeVirtualPopulateQuery(ctx);
 
 					expect(res).toEqual([]);
 				});
@@ -830,7 +816,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					});
 					adapter.init(broker, service);
 					const ctx = { service, params: { populate: ["firstVirtual", "secondVirtual", "thirdVirtual", "fourthVirtual"]}};
-					const res = adapter.getVirtualPopulateQuery(ctx);
+					const res = adapter.getNativeVirtualPopulateQuery(ctx);
 
 					expect(res).toHaveLength(3);
 
@@ -893,7 +879,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					});
 					adapter.init(broker, service);
 					const ctx = { service, params: { populate: ["firstVirtual", "secondVirtual", "thirdVirtual"]}};
-					const res = adapter.getVirtualPopulateQuery(ctx);
+					const res = adapter.getNativeVirtualPopulateQuery(ctx);
 
 					expect(res).toHaveLength(3);
 

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -926,7 +926,7 @@ if (process.versions.node.split(".")[0] < 14) {
 				adapter.init(broker, service);
 				const ctx = { service, params: {}};
 				const json = {_id: "xxx", foo: "yyy", bar: "zzz"};
-				const res = adapter.mapVirtualsToLocalFields(ctx, json);
+				adapter.mapVirtualsToLocalFields(ctx, json);
 
 				expect(json).toEqual({
 					_id: "xxx",


### PR DESCRIPTION
### Handle virtual population in a dedicated method of the mongoose adapter

I've separated, in a dedicated method, the code that handles the virtuals population. It allows the code to be more readable and easier to unit test.

Also I've included some short-circuits to avoid useless overhead and keep the virtual step as fast as possible, especially when it need to be bypassed.

Now, You can also disable the virtual population mechanism by adding `{virtuals: false}` in the service settings (request made by @thib3113). Note that letting the service decide by itself is now nearly as fast as adding this option.

### Overridding virtual populate defaults

You can now override populate options for each virtuals separately by providing an object in the service `settings.virtuals`.

example:
```js
{
  virtuals: {
    myVirtual: {
      select: "foo bar baz",
      options: { lean: false },
      transform: (doc) => doc,
    }
  }
}
```

### Remove restricted field projection in virtual populate if there is a match clause

I recently came accross an issue involving virtuals with a `match` clause.  

When I implemented the virtual population the first time, I intentionally limited the retrieved fields to the `_id` only to optimize memory/bandwith usage.
Unfortunately it has the side effect to prevent virtual `match` clauses from filtering properly.  

Indeed, mongoose execute the `match` clause as a filter on the populated list but not in the populate query itself as I previously though.  
Thus, when the virtual has a `match` clause, we need to retrieve the whole document to allow its proper execution.  

I also allow the population of virtuals using the `refPath` option, which is not documented but allowed by the code. Previously only virtuals with `ref` option would have been populated. [see code](https://github.com/Automattic/mongoose/blob/master/lib/options/VirtualOptions.js#L39)
