### PR TITLE
imp(core): Modify the entry value of the default setting to undefined…

### DIFF
--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -49,13 +49,13 @@ module.exports = {
 		idField: "_id",
 
 		/** @type {Array<String>?} Field filtering list. It must be an `Array`. If the value is `null` or `undefined` doesn't filter the fields of entities. */
-		fields: null,
+		fields: undefined,
 
 		/** @type {Array<String>?} List of excluded fields. It must be an `Array`. The value is `null` or `undefined` will be ignored. */
-		excludeFields: null,
+		excludeFields: undefined,
 
 		/** @type {Array?} Schema for population. [Read more](#populating). */
-		populates: null,
+		populates: undefined,
 
 		/** @type {Number} Default page size in `list` action. */
 		pageSize: 10,
@@ -67,7 +67,7 @@ module.exports = {
 		maxLimit: -1,
 
 		/** @type {Object|Function} Validator schema or a function to validate the incoming entity in `create` & 'insert' actions. */
-		entityValidator: null,
+		entityValidator: undefined,
 
 		/** @type {Boolean} Whether to use dot notation or not when updating an entity. Will **not** convert Array to dot notation. Default: `false` */
 		useDotNotation: false,

--- a/packages/moleculer-db/test/unit/index.actions.spec.js
+++ b/packages/moleculer-db/test/unit/index.actions.spec.js
@@ -56,14 +56,14 @@ describe("Test DbService actions", () => {
 	it("should set default settings", () => {
 		expect(service.adapter).toEqual(adapter);
 		expect(service.settings).toEqual({
-			entityValidator: null,
-			fields: null,
-			excludeFields: null,
+			entityValidator: undefined,
+			fields: undefined,
+			excludeFields: undefined,
 			idField: "_id",
 			maxLimit: -1,
 			maxPageSize: 100,
 			pageSize: 10,
-			populates: null,
+			populates: undefined,
 			useDotNotation: false,
 			cacheCleanEventType: "broadcast"
 		});

--- a/packages/moleculer-db/test/unit/index.spec.js
+++ b/packages/moleculer-db/test/unit/index.spec.js
@@ -49,14 +49,14 @@ describe("Test DbService actions", () => {
 	it("should set default settings", () => {
 		expect(service.adapter).toEqual(adapter);
 		expect(service.settings).toEqual({
-			entityValidator: null,
-			fields: null,
-			excludeFields: null,
+			entityValidator: undefined,
+			fields: undefined,
+			excludeFields: undefined,
 			idField: "_id",
 			maxLimit: -1,
 			maxPageSize: 100,
 			pageSize: 10,
-			populates: null,
+			populates: undefined,
 			useDotNotation: false,
 			cacheCleanEventType: "broadcast"
 		});


### PR DESCRIPTION
Limitation in the `mergeSchemaSettings` function ([service.js#L668](https://github.com/moleculerjs/moleculer/blob/da2aabcc7e5254ac3ce2de689bac3ce3d16033b8/src/service.js#L668)), where the default `moleculer-db` setting's entry value was set to `null`, preventing it from being overridden by other mixins.

By changing the default entry value to `undefined`, it now aligns with Lodash’s `defaultsDeep` method, which prioritizes values that are not `undefined`