### PR TITLE
fix: updated ecmaVersion to 2022

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
 	"extends": "eslint:recommended",
 	"parserOptions": {
 		"sourceType": "module",
-		"ecmaVersion": "2018"
+		"ecmaVersion": "2022"
 	},
 	"rules": {
 		"indent": [


### PR DESCRIPTION
I've noticed some ESLint errors due to mismatched EcmaScript version and modern JavaScript syntax.

like to here
![image](https://github.com/moleculerjs/moleculer-db/assets/47012892/a44b63ba-56f4-4a58-8952-b2c92d7b349d)


Updating ecmaVersion in .eslintrc.js on this PR solves this problem.