### PR TITLE
Replace deprecated findByIdAndRemove with findByIdAndDelete

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -289,7 +289,7 @@ class MongooseDbAdapter {
 	 * @memberof MongooseDbAdapter
 	 */
 	removeById(_id) {
-		return this.model.findByIdAndRemove(_id);
+		return this.model.findByIdAndDelete(_id);
 	}
 
 	/**

--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -50,7 +50,7 @@ if (process.versions.node.split(".")[0] < 14) {
 			updateMany: jest.fn(() => Promise.resolve({ modifiedCount: 2 })),
 			findByIdAndUpdate: jest.fn(() => Promise.resolve(doc)),
 			deleteMany: jest.fn(() => Promise.resolve({ deletedCount: 2 })),
-			findByIdAndRemove: jest.fn(() => Promise.resolve()),
+			findByIdAndDelete: jest.fn(() => Promise.resolve()),
 		}
 	);
 
@@ -643,10 +643,10 @@ if (process.versions.node.split(".")[0] < 14) {
 				.catch(protectReject)
 				.then(() => {
 					expect(
-						adapter.model.findByIdAndRemove
+						adapter.model.findByIdAndDelete
 					).toHaveBeenCalledTimes(1);
 					expect(
-						adapter.model.findByIdAndRemove
+						adapter.model.findByIdAndDelete
 					).toHaveBeenCalledWith(5);
 				});
 		});


### PR DESCRIPTION
As of mongoose v8 [Model.findByIdAndRemove()](https://mongoosejs.com/docs/7.x/docs/api/model.html#Model.findByIdAndRemove()) has been deprecated. Since [Model.findByIdAndDelete()](https://mongoosejs.com/docs/api/model.html#Model.findByIdAndDelete()) provides the same functionality, and is present in all versions (v5 to v8) this PR does the drop in replacement.