### PR TITLE
Remove bluebird from moleculer-db-adapter-couchdb-nano

### DIFF
--- a/packages/moleculer-db-adapter-couchdb-nano/examples/integration/index.js
+++ b/packages/moleculer-db-adapter-couchdb-nano/examples/integration/index.js
@@ -4,7 +4,8 @@ const {ServiceBroker} = require("moleculer");
 const StoreService = require("../../../moleculer-db/index");
 const CouchAdapter = require("../../index");
 const ModuleChecker = require("../../../moleculer-db/test/checker");
-const Promise = require("bluebird");
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 // Create broker
 const broker = new ServiceBroker({
@@ -36,7 +37,7 @@ const checker = new ModuleChecker(11);
 // Start checks
 function start() {
 	Promise.resolve()
-		.delay(500)
+		.then(() => delay(500))
 		.then(() => checker.execute())
 		.catch(console.error)
 		.then(() => broker.stop())

--- a/packages/moleculer-db-adapter-couchdb-nano/examples/simple/index.js
+++ b/packages/moleculer-db-adapter-couchdb-nano/examples/simple/index.js
@@ -4,7 +4,8 @@ const {ServiceBroker} = require("moleculer");
 const StoreService = require("../../../moleculer-db/index");
 const ModuleChecker = require("../../../moleculer-db/test/checker");
 const CouchAdapter = require("../../index");
-const Promise = require("bluebird");
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 // Create broker
 const broker = new ServiceBroker({
@@ -38,7 +39,7 @@ const checker = new ModuleChecker(21);
 // Start checks
 function start() {
 	Promise.resolve()
-		.delay(500)
+		.then(() => delay(500))
 		.then(() => checker.execute())
 		.catch(console.error)
 		.then(() => broker.stop())

--- a/packages/moleculer-db-adapter-couchdb-nano/package-lock.json
+++ b/packages/moleculer-db-adapter-couchdb-nano/package-lock.json
@@ -1358,7 +1358,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -1732,7 +1733,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "boxen": {
       "version": "5.1.2",
@@ -4319,7 +4321,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -5032,7 +5035,8 @@
       "version": "8.6.4",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
       "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "marked": {
       "version": "4.0.16",
@@ -6739,6 +6743,23 @@
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6758,23 +6779,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {
@@ -7435,7 +7439,8 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/packages/moleculer-db-adapter-couchdb-nano/package.json
+++ b/packages/moleculer-db-adapter-couchdb-nano/package.json
@@ -50,7 +50,6 @@
     "node": ">= 8.x.x"
   },
   "dependencies": {
-    "bluebird": "^3.7.2",
     "nano": "^9.0.5"
   }
 }

--- a/packages/moleculer-db-adapter-couchdb-nano/src/index.js
+++ b/packages/moleculer-db-adapter-couchdb-nano/src/index.js
@@ -7,7 +7,6 @@
 "use strict";
 
 const _ = require("lodash");
-const Promise = require("bluebird");
 const { ServiceSchemaError } = require("moleculer").Errors;
 const Nano = require("nano");
 


### PR DESCRIPTION
This PR removes the no longer supported `bluebird` package from couchdb nano adapter.

See [deprecation warning](https://github.com/petkaantonov/bluebird/?tab=readme-ov-file#%EF%B8%8Fnote%EF%B8%8F)