### PR TITLE
Remove bluebird from moleculer-db-adapter-knex

### DIFF
--- a/proposal/moleculer-db-adapter-knex/examples/simple/index.js
+++ b/proposal/moleculer-db-adapter-knex/examples/simple/index.js
@@ -4,7 +4,8 @@ let { ServiceBroker } = require("moleculer");
 let StoreService = require("../../../moleculer-db/index");
 let ModuleChecker = require("../../../moleculer-db/test/checker");
 let KnexAdapter = require("../../index");
-let Promise = require("bluebird");
+
+const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
 // Create broker
 let broker = new ServiceBroker({
@@ -47,11 +48,11 @@ const checker = new ModuleChecker(24);
 // Start checks
 function start() {
 	return Promise.resolve()
-		.delay(500)
+		.then(() => delay(500))
 		.then(() => checker.execute())
 		.catch(console.error)
 		.then(() => broker.stop())
-		.then(() => checker.printTotal());	
+		.then(() => checker.printTotal());
 }
 
 // --- TEST CASES ---
@@ -110,7 +111,7 @@ checker.add("INSERT MANY", () => adapter.insertMany([
 checker.add("COUNT", () => adapter.count(), res => {
 	console.log(res);
 	return res == 3;
-});		
+});
 
 // Find
 checker.add("FIND by query", () => adapter.find({ query: { title: "Last" } }), res => {
@@ -153,8 +154,8 @@ checker.add("GET BY IDS", () => adapter.findByIds([ids[2], ids[0]]), res => {
 });
 
 // Update a posts
-checker.add("UPDATE", () => adapter.updateById(ids[2], { $set: { 
-	title: "Last 2", 
+checker.add("UPDATE", () => adapter.updateById(ids[2], { $set: {
+	title: "Last 2",
 	updatedAt: new Date(),
 	status: true
 }}), doc => {
@@ -163,7 +164,7 @@ checker.add("UPDATE", () => adapter.updateById(ids[2], { $set: {
 });
 
 // Update by query
-checker.add("UPDATE BY QUERY", () => adapter.updateMany({ votes: { $lt: 5 }}, { 
+checker.add("UPDATE BY QUERY", () => adapter.updateMany({ votes: { $lt: 5 }}, {
 	$set: { status: false }
 }), count => {
 	console.log("Updated: ", count);
@@ -180,7 +181,7 @@ checker.add("REMOVE BY QUERY", () => adapter.removeMany({ votes: { $lt: 5 }}), c
 checker.add("COUNT", () => adapter.count(), res => {
 	console.log(res);
 	return res == 1;
-});	
+});
 
 // Remove by ID
 checker.add("REMOVE BY ID", () => adapter.removeById(ids[1]), doc => {

--- a/proposal/moleculer-db-adapter-knex/src/index.js
+++ b/proposal/moleculer-db-adapter-knex/src/index.js
@@ -7,7 +7,6 @@
 "use strict";
 
 const _ 			= require("lodash");
-const Promise		= require("bluebird");
 const Knex 			= require("knex");
 
 class KnexDbAdapter {


### PR DESCRIPTION
This PR removes the no longer supported `bluebird` package from knex adapter.

It also replace `let` statements with `const` statement when possible.

See [deprecation warning](https://github.com/petkaantonov/bluebird/?tab=readme-ov-file#%EF%B8%8Fnote%EF%B8%8F).