### PR TITLE
Handle multiple mongoose connections for service with schema and modelName

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
+++ b/packages/moleculer-db-adapter-mongoose/test/unit/index.spec.js
@@ -253,10 +253,7 @@ if (process.versions.node.split(".")[0] < 14) {
 				mongoose.createConnection = jest.fn(() => {
 					mongoose.connection.readyState =
 						mongoose.connection.states.connected;
-					return {
-						connection: { db: fakeDb, ...fakeDb },
-						model: jest.fn(() => fakeModel),
-					};
+					return mongoose.connection;
 				});
 
 				adapter.opts = {


### PR DESCRIPTION
Currently, the adapter uses `mongoose.connection` for all database interactions. This approach becomes problematic when dealing with multiple databases, as it can lead to confusion and potential conflicts.

This PR handle for service with schema and modelName where it will spawn up new mongoose connection using createConnection. We will use "this.conn" on MongooseDbAdapter instead of "mongoose.connection".