### PR TITLE
fix: use own object flattening function that supports class objects

### DIFF
--- a/packages/moleculer-db/package-lock.json
+++ b/packages/moleculer-db/package-lock.json
@@ -2708,11 +2708,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",

--- a/packages/moleculer-db/package.json
+++ b/packages/moleculer-db/package.json
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "@seald-io/nedb": "^3.0.0",
-    "flat": "^5.0.2",
     "lodash": "^4.17.21"
   }
 }

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -7,13 +7,11 @@
 "use strict";
 
 const _ = require("lodash");
-const { flatten } = require("flat");
 const { MoleculerClientError, ValidationError } = require("moleculer").Errors;
 const { EntityNotFoundError } = require("./errors");
 const MemoryAdapter = require("./memory-adapter");
 const pkg = require("../package.json");
-const util = require("util");
-const { copyFieldValueByPath } = require("./utils");
+const { copyFieldValueByPath, flatten } = require("./utils");
 const stringToPath = require("lodash/_stringToPath");
 
 /**

--- a/packages/moleculer-db/src/index.js
+++ b/packages/moleculer-db/src/index.js
@@ -1026,7 +1026,7 @@ module.exports = {
 					});
 
 					if (this.settings.useDotNotation)
-						sets = flatten(sets, { safe: true });
+						sets = flatten(sets);
 
 					return sets;
 				})

--- a/packages/moleculer-db/src/utils.js
+++ b/packages/moleculer-db/src/utils.js
@@ -79,11 +79,7 @@ function flatten(obj, prefix = "") {
 		const value = obj[key];
 
 		// Check if value is a plain object (not array, not null, and constructor is Object)
-		const isPlainObject =
-			typeof value === "object" &&
-			value !== null &&
-			!Array.isArray(value) &&
-			value.constructor === Object;
+		const isPlainObject = typeof value === "object" && value && value.constructor === Object;
 
 		// If it's a plain object, flatten it recursively
 		// Otherwise, keep the value as is (handles primitives, null, undefined, arrays, dates, ObjectId, etc.)

--- a/packages/moleculer-db/src/utils.js
+++ b/packages/moleculer-db/src/utils.js
@@ -32,3 +32,65 @@ function copyFieldValueByPath(doc, paths, res, pathIndex = 0, cachePaths = []) {
 }
 
 exports.copyFieldValueByPath = copyFieldValueByPath;
+
+/**
+ * Flattens a JavaScript object using dot notation while preserving arrays and non-plain objects
+ * @param {Object} obj - The object to flatten
+ * @param {String} [prefix=""] - The prefix to use for nested keys (used internally for recursion)
+ * @returns {Object} A flattened object with dot notation keys
+ *
+ * @example
+ * const input = {
+ *   name: "John",
+ *   address: {
+ *     street: "Main St",
+ *     location: {
+ *       city: "Boston",
+ *       country: "USA"
+ *     }
+ *   },
+ *   account: {
+ *     createdAt: new Date("2024-01-01"),
+ *     settings: {
+ *       theme: null,
+ *       language: undefined
+ *     }
+ *   },
+ *   scores: [85, 90, 95],
+ *   _id: ObjectId("507f1f77bcf86cd799439011")
+ * };
+ *
+ * // Returns:
+ * // {
+ * //   "name": "John",
+ * //   "address.street": "Main St",
+ * //   "address.location.city": "Boston",
+ * //   "address.location.country": "USA",
+ * //   "account.createdAt": Date("2024-01-01T00:00:00.000Z"),
+ * //   "account.settings.theme": null,
+ * //   "account.settings.language": undefined,
+ * //   "scores": [85, 90, 95],
+ * //   "_id": ObjectId("507f1f77bcf86cd799439011")
+ * // }
+ */
+function flatten(obj, prefix = "") {
+	return Object.keys(obj).reduce((acc, key) => {
+		const prefixedKey = prefix ? `${prefix}.${key}` : key;
+		const value = obj[key];
+
+		// Check if value is a plain object (not array, not null, and constructor is Object)
+		const isPlainObject =
+			typeof value === "object" &&
+			value !== null &&
+			!Array.isArray(value) &&
+			value.constructor === Object;
+
+		// If it's a plain object, flatten it recursively
+		// Otherwise, keep the value as is (handles primitives, null, undefined, arrays, dates, ObjectId, etc.)
+		return isPlainObject
+			? { ...acc, ...flatten(value, prefixedKey) }
+			: { ...acc, [prefixedKey]: value };
+	}, {});
+}
+
+exports.flatten = flatten;

--- a/packages/moleculer-db/test/unit/utils.spec.js
+++ b/packages/moleculer-db/test/unit/utils.spec.js
@@ -5,47 +5,49 @@ const { flatten } = require("../../src/utils");
 if (process.versions.node.split(".")[0] < 14) {
 	console.log("Skipping utils tests because node version is too low");
 	it("Skipping utils tests because node version is too low", () => {});
-}
+} else {
 
-describe("Test Utils", () => {
-	describe("flatten", () => {
-		it("should properly flatten a given object", () => {
-			const { randomUUID } = require("crypto");
-			const uuid = randomUUID();
-			const date = new Date("2024-01-01");
-			const obj = {
-				name: "John",
-				address: {
-					street: "Main St",
-					location: {
-						city: "Boston",
-						country: "USA"
-					}
-				},
-				account: {
-					createdAt: date,
-					identifier: uuid,
-					settings: {
-						theme: null,
-						language: undefined
-					}
-				},
-				scores: [85, 90, 95],
-			};
+	describe("Test Utils", () => {
+		describe("flatten", () => {
+			it("should properly flatten a given object", () => {
+				const {randomUUID} = require("crypto");
+				const uuid = randomUUID();
+				const date = new Date("2024-01-01");
+				const obj = {
+					name: "John",
+					address: {
+						street: "Main St",
+						location: {
+							city: "Boston",
+							country: "USA"
+						}
+					},
+					account: {
+						createdAt: date,
+						identifier: uuid,
+						settings: {
+							theme: null,
+							language: undefined
+						}
+					},
+					scores: [85, 90, 95],
+				};
 
-			const expected = {
-				"name": "John",
-				"address.street": "Main St",
-				"address.location.city": "Boston",
-				"address.location.country": "USA",
-				"account.createdAt": date,
-				"account.identifier": uuid,
-				"account.settings.theme": null,
-				"account.settings.language": undefined,
-				"scores": [85, 90, 95],
-			};
+				const expected = {
+					"name": "John",
+					"address.street": "Main St",
+					"address.location.city": "Boston",
+					"address.location.country": "USA",
+					"account.createdAt": date,
+					"account.identifier": uuid,
+					"account.settings.theme": null,
+					"account.settings.language": undefined,
+					"scores": [85, 90, 95],
+				};
 
-			expect(flatten(obj)).toEqual(expected);
+				expect(flatten(obj)).toEqual(expected);
+			});
 		});
 	});
-});
+
+}

--- a/packages/moleculer-db/test/unit/utils.spec.js
+++ b/packages/moleculer-db/test/unit/utils.spec.js
@@ -2,56 +2,65 @@
 
 const { flatten } = require("../../src/utils");
 
-if (process.versions.node.split(".")[0] < 14) {
-	console.log("Skipping utils tests because node version is too low");
-	it("Skipping utils tests because node version is too low", () => {});
-} else {
+class ObjectId {
+	constructor() {
+		this.timestamp = Math.floor(Date.now() / 1000).toString(16).padStart(8, "0");
+		this.machineId = Math.floor(Math.random() * 16777216).toString(16).padStart(6, "0");
+		this.processId = Math.floor(Math.random() * 65536).toString(16).padStart(4, "0");
+		this.counter = Math.floor(Math.random() * 16777216).toString(16).padStart(6, "0");
+	}
 
-	describe("Test Utils", () => {
-		describe("flatten", () => {
-			it("should properly flatten a given object", () => {
-				const {randomUUID} = require("crypto");
-				const uuid = randomUUID();
-				const date = new Date("2024-01-01");
-				const obj = {
-					name: "John",
-					active: true,
-					address: {
-						street: "Main St",
-						location: {
-							city: "Boston",
-							country: "USA"
-						}
-					},
-					account: {
-						createdAt: date,
-						identifier: uuid,
-						isSync: false,
-						settings: {
-							theme: null,
-							language: undefined
-						}
-					},
-					scores: [85, 90, 95],
-				};
+	toString() {
+		return this.timestamp + this.machineId + this.processId + this.counter;
+	}
 
-				const expected = {
-					"name": "John",
-					"active": true,
-					"address.street": "Main St",
-					"address.location.city": "Boston",
-					"address.location.country": "USA",
-					"account.createdAt": date,
-					"account.identifier": uuid,
-					"account.settings.theme": null,
-					"account.settings.language": undefined,
-					"account.isSync": false,
-					"scores": [85, 90, 95],
-				};
+	getTimestamp() {
+		return new Date(parseInt(this.timestamp, 16) * 1000);
+	}
+}
 
-				expect(flatten(obj)).toEqual(expected);
-			});
+describe("Test Utils", () => {
+	describe("flatten", () => {
+		it("should properly flatten a given object", () => {
+			const oid = new ObjectId();
+			const date = new Date("2024-01-01");
+			const obj = {
+				name: "John",
+				active: true,
+				address: {
+					street: "Main St",
+					location: {
+						city: "Boston",
+						country: "USA"
+					}
+				},
+				account: {
+					createdAt: date,
+					identifier: oid,
+					isSync: false,
+					settings: {
+						theme: null,
+						language: undefined
+					}
+				},
+				scores: [85, 90, 95],
+			};
+
+			const expected = {
+				"name": "John",
+				"active": true,
+				"address.street": "Main St",
+				"address.location.city": "Boston",
+				"address.location.country": "USA",
+				"account.createdAt": date,
+				"account.identifier": oid,
+				"account.settings.theme": null,
+				"account.settings.language": undefined,
+				"account.isSync": false,
+				"scores": [85, 90, 95],
+			};
+
+			expect(flatten(obj)).toEqual(expected);
 		});
 	});
-
-}
+});

--- a/packages/moleculer-db/test/unit/utils.spec.js
+++ b/packages/moleculer-db/test/unit/utils.spec.js
@@ -1,11 +1,16 @@
 "use strict";
 
 const { flatten } = require("../../src/utils");
-const { randomUUID } = require("crypto");
+
+if (process.versions.node.split(".")[0] < 14) {
+	console.log("Skipping utils tests because node version is too low");
+	it("Skipping utils tests because node version is too low", () => {});
+}
 
 describe("Test Utils", () => {
 	describe("flatten", () => {
 		it("should properly flatten a given object", () => {
+			const { randomUUID } = require("crypto");
 			const uuid = randomUUID();
 			const date = new Date("2024-01-01");
 			const obj = {

--- a/packages/moleculer-db/test/unit/utils.spec.js
+++ b/packages/moleculer-db/test/unit/utils.spec.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const { flatten } = require("../../src/utils");
+const { randomUUID } = require("crypto");
+
+describe("Test Utils", () => {
+	describe("flatten", () => {
+		it("should properly flatten a given object", () => {
+			const uuid = randomUUID();
+			const date = new Date("2024-01-01");
+			const obj = {
+				name: "John",
+				address: {
+					street: "Main St",
+					location: {
+						city: "Boston",
+						country: "USA"
+					}
+				},
+				account: {
+					createdAt: date,
+					identifier: uuid,
+					settings: {
+						theme: null,
+						language: undefined
+					}
+				},
+				scores: [85, 90, 95],
+			};
+
+			const expected = {
+				"name": "John",
+				"address.street": "Main St",
+				"address.location.city": "Boston",
+				"address.location.country": "USA",
+				"account.createdAt": date,
+				"account.identifier": uuid,
+				"account.settings.theme": null,
+				"account.settings.language": undefined,
+				"scores": [85, 90, 95],
+			};
+
+			expect(flatten(obj)).toEqual(expected);
+		});
+	});
+});

--- a/packages/moleculer-db/test/unit/utils.spec.js
+++ b/packages/moleculer-db/test/unit/utils.spec.js
@@ -15,6 +15,7 @@ if (process.versions.node.split(".")[0] < 14) {
 				const date = new Date("2024-01-01");
 				const obj = {
 					name: "John",
+					active: true,
 					address: {
 						street: "Main St",
 						location: {
@@ -25,6 +26,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					account: {
 						createdAt: date,
 						identifier: uuid,
+						isSync: false,
 						settings: {
 							theme: null,
 							language: undefined
@@ -35,6 +37,7 @@ if (process.versions.node.split(".")[0] < 14) {
 
 				const expected = {
 					"name": "John",
+					"active": true,
 					"address.street": "Main St",
 					"address.location.city": "Boston",
 					"address.location.country": "USA",
@@ -42,6 +45,7 @@ if (process.versions.node.split(".")[0] < 14) {
 					"account.identifier": uuid,
 					"account.settings.theme": null,
 					"account.settings.language": undefined,
+					"account.isSync": false,
 					"scores": [85, 90, 95],
 				};
 


### PR DESCRIPTION
This PR removes the `flat` npm package to replace the flattening function by an homemade one that only flattens plain old javascript objects and let other structures as is.

fixes #401 