### PR TITLE
Add fields end excludeFields to sequelize query

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -363,6 +363,15 @@ class SequelizeDbAdapter {
 			}
 		}
 
+		// Fields & excludeFields
+		if (params.fields || params.excludeFields) {
+			q.attributes = {};
+			if (params.fields)
+				q.attributes.include = params.fields;
+			if (params.excludeFields)
+				q.attributes.exclude = params.excludeFields;
+		}
+
 		// Sort
 		if (params.sort) {
 			const sort = this.transformSort(params.sort);


### PR DESCRIPTION
This PR adds the values of `fields` and `excludeFields` to the Sequelize query's `attributes` field.