### PR TITLE
fix(sequelize/count): only forward allowed filters to the count cursor

### DIFF
--- a/packages/moleculer-db-adapter-sequelize/src/index.js
+++ b/packages/moleculer-db-adapter-sequelize/src/index.js
@@ -183,7 +183,12 @@ class SequelizeDbAdapter {
 	 * @memberof SequelizeDbAdapter
 	 */
 	count(filters = {}) {
-		return this.createCursor(filters, true);
+		// Only forward supported filters of sequelize count, to prevent errors with advanced sequelize features used in list() calls, like include and popualate (list() uses count for pagination and passes all params)
+		return this.createCursor({
+			query: filters.query,
+			searchFields: filters.searchFields,
+			search: filters.search
+		}, true);
 	}
 
 	/**


### PR DESCRIPTION
This change allows use of sequelizes include feature with list calls.

````
call books.list '{"query":{"stock":{"$gte":"1"}},"attributes":["id ", "name"], "include":[{"model": "authors", "as": "authors", "attributes": ["id", "name"]}]}'
````

-> 

````
{
  rows: [
    {
      id: '1',
      name: 'a',
      authors: { id: '1, name: 'Laurence, Stratmann' }
    },
    {
      id: '2',
      name: 'b',
      authors: { id: '2', name: 'Aaliyah, Bielert' }
    }
  ],
  total: 2,
  page: 1,
  pageSize: 100,
  totalPages: 1
}