### PR TITLE
fix: remove event listener declarations to avoid memory leak

### DIFF
--- a/packages/moleculer-db-adapter-mongoose/src/index.js
+++ b/packages/moleculer-db-adapter-mongoose/src/index.js
@@ -96,11 +96,6 @@ class MongooseDbAdapter {
 		}
 
 		this.service.logger.info("MongoDB adapter has connected successfully.");
-
-		/* istanbul ignore next */
-		this.conn.on("disconnected", () => this.service.logger.warn("Mongoose adapter has disconnected."));
-		this.conn.on("error", err => this.service.logger.error("MongoDB error.", err));
-		this.conn.on("reconnected", () => this.service.logger.info("Mongoose adapter has reconnected."));
 	}
 
 	/**


### PR DESCRIPTION
I removed event listener declaration from the connection script to avoid memory leaks.  

Instanciating several services including the `moleculer-db-adapter-mongoose` mixin will result on 3 event listeners declared by services, thus, node is emitting a warning on possible memory leak.  

It's better to let the user instanciate his own event listener to avoid this issue.

Here is the warnings I got:
<img width="811" height="379" alt="image" src="https://github.com/user-attachments/assets/030f4c0a-8744-4fb0-8bb1-e83da5cf6f18" />
